### PR TITLE
v0.0.2 reality hardening

### DIFF
--- a/PROOF.md
+++ b/PROOF.md
@@ -1,0 +1,124 @@
+# DevTime — PROOF
+
+Evidence that DevTime V0 does what it claims, on real repositories — and an honest
+list of where it is still weak. Built and validated locally; AI off, cloud off,
+telemetry off, no code execution, no network.
+
+## 1. Current V0 status
+
+A local-first Engineering Intelligence CLI (`dtc`) that scans a repository, detects
+concepts, links them to evidence, generates governed claims with visible
+uncertainty, scores Understanding Debt, reviews diffs against memory, and produces
+Context Packs for humans and AI agents. SQLite memory in `.devtime/`.
+
+- Tests: **27 passing** (`pytest`) — unit, integration, and 13 fixtures.
+- Trust laws enforced as executable gates: no claim without evidence; usage is not
+  decision; uncertainty is output; ignored secrets never become evidence.
+
+## 2. Commands that work
+
+```
+dtc init                         # create local memory
+dtc scan                         # detect concepts/evidence/claims (no code exec, no network)
+dtc concepts                     # list detected concepts with confidence + debt
+dtc explain <concept>            # claims + evidence + uncertainty + Understanding Debt
+dtc evidence <concept>           # raw evidence list with strength
+dtc context <concept> --mode risk# governed Context Pack for agents
+dtc risk --diff --base <ref>     # memory-aware review of a diff
+dtc decision add --title .. --body ..   # record rationale (closes Understanding Debt)
+dtc doctor --privacy             # privacy/boundary checks
+dtc export --format json|markdown
+dtc status / dtc reset
+```
+
+## 3. Demo repo proof (`examples/demo-saas`)
+
+`dtc scan` detects Authentication, Billing Webhooks, Background Jobs, Data Export,
+Admin Permissions. Billing Webhooks correctly reports **"No decision was found"**
+and scores lower than Authentication (which has an ADR). `dtc risk --diff` on a
+retry-behavior change flags: *"Retry behavior changed without duplicate-delivery
+test changes"* (high). `dtc decision add` drops Billing Webhooks debt 56 → 72 and
+clears the uncertainty.
+
+## 4. Real-repo validation results
+
+Validated against three real repositories (see `reports/reality-validation/`):
+API Graveyard (FastAPI + TS), Snapilio (Next.js/SST), SaaSVoice (Next.js/SST).
+
+| Repo | Files | Signals | Key failure found |
+|------|-------|---------|-------------------|
+| API Graveyard | 355 | 1468 | "Billing Webhooks" false positive on a generic webhook system; Context Pack fabricated billing warnings; migration file used as Background Jobs evidence; e2e specs polluting evidence |
+| Snapilio | 186 | 649 | Next.js App Router routes invisible → every concept degraded to weak dependency evidence; `//` path bug |
+| SaaSVoice | 125 | 508 | NextAuth + all API routes missed; auth reported with no route evidence |
+
+The single highest-leverage finding (two of three repos): **DevTime could not see the
+Next.js App Router**, the most common TS API stack.
+
+## 5. Before / after
+
+**Snapilio — Authentication**
+- Before: `confidence: medium`, evidence `dependency, doc, middleware`; claim was
+  only "has related dependencies present".
+- After: `confidence: high`, evidence now includes `route`; claim "Authentication
+  has active route handling" anchored on real `app/api/.../route.ts` handlers.
+
+**Snapilio — Billing Webhooks**
+- Before: weak dependency-only, no behavior.
+- After: `route` evidence + "has active route handling", anchored on the real
+  `app/api/paypal/webhook/route.ts`.
+
+**API Graveyard — Background Jobs**
+- Before: evidence included `backend/alembic/versions/..._add_jobs.py` (a DB migration).
+- After: migrations excluded; no migration files in evidence.
+
+**API Graveyard — Context Pack**
+- Before: "Do Not Change: Signature verification behavior / Subscription state
+  transition mapping" — fabricated, no billing evidence in repo.
+- After: warnings derived from actual evidence ("Token issuing and verification
+  behavior", "Authorization / protected-route behavior", "Request handling for …").
+
+## 6. Fixtures added (10 new, from real failures)
+
+| Fixture | Locks in |
+|---------|----------|
+| `nextjs/nextjs-data-export-route` | App Router `route.ts` GET → Data Export route |
+| `nextjs/nextauth-authentication` | `api/auth/[...nextauth]/route.ts` → Authentication route |
+| `nextjs/paypal-webhook-is-billing` | PayPal webhook route → Billing Webhooks (real billing) |
+| `nextjs/nextjs-file-upload-route` | upload route → File Uploads |
+| `nextjs/nextjs-admin-route` | admin route → Admin Permissions |
+| `webhooks/generic-webhook-not-billing` | generic webhook must NOT be "Billing Webhooks" |
+| `jobs/migration-not-background-job` | migration file must NOT be Background Jobs evidence |
+| `evidence/e2e-spec-weak` | e2e UI spec must not define a concept alone |
+| `evidence/dependency-only-weak` | dependency-only concept stays weak + uncertain |
+| `express/express-named-router` | `authRouter.post(...)` detected (named routers) |
+
+Backed by scanner/claim fixes: Next.js extractor (`scanner/extractors/nextjs.py`),
+billing-evidence gate + weak-only gate (`intelligence/concepts.py`), evidence-derived
+Context Pack warnings (`intelligence/context_pack.py`), migration exclusion and e2e
+down-weighting (`scanner/signals.py`, `scanner/extractors/tests.py`), path
+normalization (`scanner/file_walker.py`).
+
+## 7. Known limitations (honest)
+
+- **Detection is pattern/regex-based.** Express, FastAPI, and Next.js App Router are
+  covered; other frameworks (NestJS, Django, Flask, Rails, Go) are not yet parsed.
+- **Billing gate is repo-wide, not file-local.** A repo with billing tokens anywhere
+  can still allow a "Billing Webhooks" concept even if the matched webhook routes are
+  generic. Tightening to file-locality is a next step.
+- **No git-history signals.** Freshness is a fixed placeholder; ownership is always
+  unconfirmed; lineage is not yet implemented.
+- **Performance:** the file walker descends into ignored directories before filtering
+  (~27s on a 355-file repo with large build output). Needs directory pruning.
+- **MCP transport not wired.** Tool logic exists; the server only describes the
+  read-only contract.
+- **AI provider disabled.** No narration provider is shipped.
+- Validation covered 3 real repos + the demo. Two more (a random open-source TS repo
+  and a standalone FastAPI repo) are planned on dedicated branches.
+
+## 8. Next recommended milestone
+
+Tighten the billing gate to file-locality, add directory pruning to the walker, then
+expand validation to 2 more open-source repos and grow the fixture suite. Only after
+that: `dtc doctor`, `dtc claim show <id>`, `dtc export --markdown` polish.
+
+> The milestone reached: **DevTime learned 10 real repo patterns and will not forget them.**

--- a/PROOF.md
+++ b/PROOF.md
@@ -11,9 +11,24 @@ concepts, links them to evidence, generates governed claims with visible
 uncertainty, scores Understanding Debt, reviews diffs against memory, and produces
 Context Packs for humans and AI agents. SQLite memory in `.devtime/`.
 
-- Tests: **27 passing** (`pytest`) — unit, integration, and 13 fixtures.
+- Tests: **33 passing** (`pytest`) — unit, integration, and 16 fixtures.
 - Trust laws enforced as executable gates: no claim without evidence; usage is not
   decision; uncertainty is output; ignored secrets never become evidence.
+
+### v0.0.2 Reality Hardening
+
+Two highest-confidence limitations from Reality Validation, fixed (no new features):
+
+- **File-local Billing Webhooks gate.** Billing Webhooks now requires webhook and
+  billing evidence to be local to each other (same file / provider signature
+  handler), not merely present somewhere in the repo. Result on real repos: API
+  Graveyard's generic webhook-delivery system is **no longer** mislabelled Billing
+  Webhooks (its only billing association was an e2e spec path), while Snapilio's
+  PayPal webhook and the demo's Stripe webhook are still correctly detected.
+- **Walker prunes ignored directories before traversal.** node_modules, .git,
+  build output, .next/.sst, .devtime, etc. are skipped instead of walked-then-
+  filtered. API Graveyard scan time dropped from **~27.3s to ~0.48s** (≈56×), with
+  identical privacy behaviour (secrets under ignored paths are never visited).
 
 ## 2. Commands that work
 
@@ -102,13 +117,12 @@ normalization (`scanner/file_walker.py`).
 
 - **Detection is pattern/regex-based.** Express, FastAPI, and Next.js App Router are
   covered; other frameworks (NestJS, Django, Flask, Rails, Go) are not yet parsed.
-- **Billing gate is repo-wide, not file-local.** A repo with billing tokens anywhere
-  can still allow a "Billing Webhooks" concept even if the matched webhook routes are
-  generic. Tightening to file-locality is a next step.
+- **Billing proximity is file-level, not function-level.** Fixed to file-local in
+  v0.0.2 (repo-wide deps and generic webhooks no longer infer Billing Webhooks). A
+  single kitchen-sink file that references both webhooks and billing in unrelated
+  code could still co-locate tokens; function/route-level proximity is a future step.
 - **No git-history signals.** Freshness is a fixed placeholder; ownership is always
   unconfirmed; lineage is not yet implemented.
-- **Performance:** the file walker descends into ignored directories before filtering
-  (~27s on a 355-file repo with large build output). Needs directory pruning.
 - **MCP transport not wired.** Tool logic exists; the server only describes the
   read-only contract.
 - **AI provider disabled.** No narration provider is shipped.
@@ -117,8 +131,10 @@ normalization (`scanner/file_walker.py`).
 
 ## 8. Next recommended milestone
 
-Tighten the billing gate to file-locality, add directory pruning to the walker, then
-expand validation to 2 more open-source repos and grow the fixture suite. Only after
-that: `dtc doctor`, `dtc claim show <id>`, `dtc export --markdown` polish.
+Billing-gate file-locality and walker pruning are done (v0.0.2). Next: V0 Public
+Readiness — README trust model, clean-install instructions, CI green from a clean
+clone, a short demo. Then expand validation to 2 more open-source repos and grow the
+fixture suite. Only after that: `dtc doctor`, `dtc claim show <id>`,
+`dtc export --markdown` polish.
 
 > The milestone reached: **DevTime learned 10 real repo patterns and will not forget them.**

--- a/fixtures/evidence/dependency-only-weak/fixture.yaml
+++ b/fixtures/evidence/dependency-only-weak/fixture.yaml
@@ -2,15 +2,16 @@ id: dependency-only-weak
 type: weak-evidence
 language: typescript
 framework: none
-# Reality Validation (SaaSVoice/Snapilio): a concept supported only by a
-# package.json dependency must stay weak and carry uncertainty (presence != behavior).
+# Reality Validation: a concept supported only by a package.json dependency must
+# stay weak and carry uncertainty (presence != behavior). Uses a non-billing
+# concept so it does not collide with the file-local Billing Webhooks gate.
 expected:
   concepts:
-    - Billing Webhooks
+    - Background Jobs
   allowed_claims:
-    - "Billing Webhooks has related dependencies present."
+    - "Background Jobs has related dependencies present."
   forbidden_claims:
-    - "Billing Webhooks has active route handling."
+    - "Background Jobs has active route handling."
   required_uncertainty:
     - "presence is not confirmed behavior"
 privacy:

--- a/fixtures/evidence/dependency-only-weak/fixture.yaml
+++ b/fixtures/evidence/dependency-only-weak/fixture.yaml
@@ -1,0 +1,17 @@
+id: dependency-only-weak
+type: weak-evidence
+language: typescript
+framework: none
+# Reality Validation (SaaSVoice/Snapilio): a concept supported only by a
+# package.json dependency must stay weak and carry uncertainty (presence != behavior).
+expected:
+  concepts:
+    - Billing Webhooks
+  allowed_claims:
+    - "Billing Webhooks has related dependencies present."
+  forbidden_claims:
+    - "Billing Webhooks has active route handling."
+  required_uncertainty:
+    - "presence is not confirmed behavior"
+privacy:
+  contains_secrets: false

--- a/fixtures/evidence/dependency-only-weak/repo/package.json
+++ b/fixtures/evidence/dependency-only-weak/repo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dep-only",
+  "dependencies": {
+    "stripe": "^15.0.0"
+  }
+}

--- a/fixtures/evidence/dependency-only-weak/repo/package.json
+++ b/fixtures/evidence/dependency-only-weak/repo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dep-only",
   "dependencies": {
-    "stripe": "^15.0.0"
+    "bullmq": "^5.0.0"
   }
 }

--- a/fixtures/evidence/e2e-spec-weak/fixture.yaml
+++ b/fixtures/evidence/e2e-spec-weak/fixture.yaml
@@ -1,0 +1,14 @@
+id: e2e-spec-weak
+type: false-positive
+language: typescript
+framework: playwright
+# Reality Validation (API Graveyard): an e2e UI spec mentioning "upload" was
+# defining File Uploads on its own. E2E specs are weak, not concept-defining.
+expected:
+  concepts: []
+  allowed_claims: []
+  forbidden_claims:
+    - "File Uploads is present in this repository."
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/evidence/e2e-spec-weak/repo/qa-automation/tests-e2e/specs/sidebar-navigation.e2e.spec.ts
+++ b/fixtures/evidence/e2e-spec-weak/repo/qa-automation/tests-e2e/specs/sidebar-navigation.e2e.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "@playwright/test";
+
+test("sidebar shows the upload and export buttons", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText("Upload")).toBeVisible();
+});

--- a/fixtures/express/express-named-router/fixture.yaml
+++ b/fixtures/express/express-named-router/fixture.yaml
@@ -1,0 +1,16 @@
+id: express-named-router
+type: regression
+language: typescript
+framework: express
+# Reality Validation (demo + common pattern): Express named routers (authRouter.post)
+# must be detected, not only literal app/router.
+expected:
+  concepts:
+    - Authentication
+  allowed_claims:
+    - "Authentication has active route handling."
+    - "Authentication uses JWT access tokens."
+  forbidden_claims: []
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/express/express-named-router/repo/src/routes/auth.ts
+++ b/fixtures/express/express-named-router/repo/src/routes/auth.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import jwt from "jsonwebtoken";
+
+export const authRouter = Router();
+
+authRouter.post("/auth/login", (req, res) => {
+  const token = jwt.sign({ sub: "u_1" }, process.env.JWT_SECRET as string);
+  return res.json({ token });
+});

--- a/fixtures/jobs/migration-not-background-job/fixture.yaml
+++ b/fixtures/jobs/migration-not-background-job/fixture.yaml
@@ -1,0 +1,14 @@
+id: migration-not-background-job
+type: false-positive
+language: python
+framework: alembic
+# Reality Validation (API Graveyard): an Alembic migration named *_add_jobs.py was
+# used as Background Jobs evidence. Migrations are schema history, not workers.
+expected:
+  concepts: []
+  allowed_claims: []
+  forbidden_claims:
+    - "Background Jobs is present in this repository."
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/jobs/migration-not-background-job/repo/backend/alembic/versions/146526398b6a_add_demo_traffic_jobs_clean.py
+++ b/fixtures/jobs/migration-not-background-job/repo/backend/alembic/versions/146526398b6a_add_demo_traffic_jobs_clean.py
@@ -1,0 +1,16 @@
+"""add demo traffic jobs
+
+Revision ID: 146526398b6a
+"""
+
+revision = "146526398b6a"
+down_revision = None
+
+
+def upgrade():
+    # Creates a 'jobs' table. This is schema history, not a worker.
+    op.create_table("jobs")
+
+
+def downgrade():
+    op.drop_table("jobs")

--- a/fixtures/nextjs/nextauth-authentication/fixture.yaml
+++ b/fixtures/nextjs/nextauth-authentication/fixture.yaml
@@ -1,0 +1,14 @@
+id: nextauth-authentication
+type: concept
+language: typescript
+framework: nextjs
+# Reality Validation (SaaSVoice): api/auth/[...nextauth]/route.ts missed as auth route.
+expected:
+  concepts:
+    - Authentication
+  allowed_claims:
+    - "Authentication has active route handling."
+  forbidden_claims: []
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/nextjs/nextauth-authentication/repo/app/api/auth/[...nextauth]/route.ts
+++ b/fixtures/nextjs/nextauth-authentication/repo/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,11 @@
+import NextAuth from "next-auth";
+
+const handler = NextAuth({ providers: [] });
+
+export async function GET(req: Request) {
+  return handler(req);
+}
+
+export async function POST(req: Request) {
+  return handler(req);
+}

--- a/fixtures/nextjs/nextjs-admin-route/fixture.yaml
+++ b/fixtures/nextjs/nextjs-admin-route/fixture.yaml
@@ -1,0 +1,13 @@
+id: nextjs-admin-route
+type: concept
+language: typescript
+framework: nextjs
+expected:
+  concepts:
+    - Admin Permissions
+  allowed_claims:
+    - "Admin Permissions has active route handling."
+  forbidden_claims: []
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/nextjs/nextjs-admin-route/repo/app/api/admin/users/route.ts
+++ b/fixtures/nextjs/nextjs-admin-route/repo/app/api/admin/users/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  if (!isAdmin(req)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  return NextResponse.json(await listUsers());
+}
+
+function isAdmin(req: Request) {
+  return req.headers.get("x-role") === "admin";
+}
+
+async function listUsers() {
+  return [];
+}

--- a/fixtures/nextjs/nextjs-data-export-route/fixture.yaml
+++ b/fixtures/nextjs/nextjs-data-export-route/fixture.yaml
@@ -1,0 +1,14 @@
+id: nextjs-data-export-route
+type: concept
+language: typescript
+framework: nextjs
+# Reality Validation (SaaSVoice): app/api/.../route.ts handlers were invisible.
+expected:
+  concepts:
+    - Data Export
+  allowed_claims:
+    - "Data Export has active route handling."
+  forbidden_claims: []
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/nextjs/nextjs-data-export-route/repo/app/api/posts/export/route.ts
+++ b/fixtures/nextjs/nextjs-data-export-route/repo/app/api/posts/export/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const rows = await loadPosts();
+  const csv = rows.map((r) => `${r.id},${r.title}`).join("\n");
+  return new NextResponse(csv, { headers: { "Content-Type": "text/csv" } });
+}
+
+async function loadPosts() {
+  return [{ id: "p_1", title: "hello" }];
+}

--- a/fixtures/nextjs/nextjs-file-upload-route/fixture.yaml
+++ b/fixtures/nextjs/nextjs-file-upload-route/fixture.yaml
@@ -1,0 +1,13 @@
+id: nextjs-file-upload-route
+type: concept
+language: typescript
+framework: nextjs
+expected:
+  concepts:
+    - File Uploads
+  allowed_claims:
+    - "File Uploads has active route handling."
+  forbidden_claims: []
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/nextjs/nextjs-file-upload-route/repo/app/api/upload/route.ts
+++ b/fixtures/nextjs/nextjs-file-upload-route/repo/app/api/upload/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const form = await req.formData();
+  const file = form.get("file");
+  await store(file);
+  return NextResponse.json({ ok: true });
+}
+
+async function store(file: unknown) {
+  return file;
+}

--- a/fixtures/nextjs/paypal-webhook-is-billing/fixture.yaml
+++ b/fixtures/nextjs/paypal-webhook-is-billing/fixture.yaml
@@ -1,0 +1,14 @@
+id: paypal-webhook-is-billing
+type: concept
+language: typescript
+framework: nextjs
+# Reality Validation (Snapilio): app/api/paypal/webhook/route.ts is a real billing webhook.
+expected:
+  concepts:
+    - Billing Webhooks
+  allowed_claims:
+    - "Billing Webhooks has active route handling."
+  forbidden_claims: []
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/nextjs/paypal-webhook-is-billing/repo/app/api/paypal/webhook/route.ts
+++ b/fixtures/nextjs/paypal-webhook-is-billing/repo/app/api/paypal/webhook/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const event = await req.json();
+  if (event.event_type === "BILLING.SUBSCRIPTION.UPDATED") {
+    await updateSubscription(event.resource);
+  }
+  return NextResponse.json({ received: true });
+}
+
+async function updateSubscription(resource: any) {
+  return resource;
+}

--- a/fixtures/webhooks/billing-webhook-local-stripe/fixture.yaml
+++ b/fixtures/webhooks/billing-webhook-local-stripe/fixture.yaml
@@ -1,0 +1,16 @@
+id: billing-webhook-local-stripe
+type: concept
+language: typescript
+framework: express
+# Reality Hardening (v0.0.2): a Stripe webhook route with signature verification and
+# a subscription state mutation, all local to the same file, IS Billing Webhooks.
+expected:
+  concepts:
+    - Billing Webhooks
+  allowed_claims:
+    - "Billing Webhooks has active route handling."
+    - "Billing Webhooks verifies webhook signatures."
+  forbidden_claims: []
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/webhooks/billing-webhook-local-stripe/repo/src/billing/webhook.ts
+++ b/fixtures/webhooks/billing-webhook-local-stripe/repo/src/billing/webhook.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string);
+export const billingRouter = Router();
+
+billingRouter.post("/api/stripe/webhook", async (req, res) => {
+  const sig = req.headers["stripe-signature"] as string;
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      (req as any).rawBody,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET as string
+    );
+  } catch {
+    return res.status(400).send("invalid_signature");
+  }
+
+  if (event.type === "customer.subscription.updated") {
+    // Subscription state mutation local to the webhook handler.
+    await updateSubscriptionState(event.data.object);
+  }
+  return res.json({ received: true });
+});
+
+async function updateSubscriptionState(subscription: any) {
+  return subscription;
+}

--- a/fixtures/webhooks/generic-webhook-not-billing/fixture.yaml
+++ b/fixtures/webhooks/generic-webhook-not-billing/fixture.yaml
@@ -1,0 +1,15 @@
+id: generic-webhook-not-billing
+type: false-positive
+language: typescript
+framework: nextjs
+# Reality Validation (API Graveyard): a generic webhook-delivery system was named
+# "Billing Webhooks" purely on the word "webhook". It must not be.
+expected:
+  concepts: []
+  allowed_claims: []
+  forbidden_claims:
+    - "Billing Webhooks is present in this repository."
+    - "Billing Webhooks has active route handling."
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/webhooks/generic-webhook-not-billing/repo/app/api/webhook-receiver/route.ts
+++ b/fixtures/webhooks/generic-webhook-not-billing/repo/app/api/webhook-receiver/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+// A generic inbound webhook receiver and delivery log. No billing, no Stripe,
+// no subscriptions, no signature verification.
+export async function POST(req: Request) {
+  const payload = await req.json();
+  await recordDelivery(payload);
+  return NextResponse.json({ stored: true });
+}
+
+export async function GET() {
+  return NextResponse.json(await listDeliveries());
+}
+
+async function recordDelivery(payload: unknown) {
+  return payload;
+}
+async function listDeliveries() {
+  return [];
+}

--- a/fixtures/webhooks/generic-webhook-plus-unrelated-billing-dep/fixture.yaml
+++ b/fixtures/webhooks/generic-webhook-plus-unrelated-billing-dep/fixture.yaml
@@ -1,0 +1,16 @@
+id: generic-webhook-plus-unrelated-billing-dep
+type: false-positive
+language: typescript
+framework: nextjs
+# Reality Hardening (v0.0.2): a generic webhook receiver in one file, plus a Stripe
+# dependency declared elsewhere (package.json), must NOT infer Billing Webhooks.
+# Billing and webhook evidence are not file-local to each other.
+expected:
+  concepts: []
+  allowed_claims: []
+  forbidden_claims:
+    - "Billing Webhooks is present in this repository."
+    - "Billing Webhooks has active route handling."
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/webhooks/generic-webhook-plus-unrelated-billing-dep/repo/app/api/webhook-receiver/route.ts
+++ b/fixtures/webhooks/generic-webhook-plus-unrelated-billing-dep/repo/app/api/webhook-receiver/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+// Generic inbound webhook receiver. No billing/payment logic in this handler.
+export async function POST(req: Request) {
+  const payload = await req.json();
+  await recordDelivery(payload);
+  return NextResponse.json({ stored: true });
+}
+
+async function recordDelivery(payload: unknown) {
+  return payload;
+}

--- a/fixtures/webhooks/generic-webhook-plus-unrelated-billing-dep/repo/package.json
+++ b/fixtures/webhooks/generic-webhook-plus-unrelated-billing-dep/repo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "generic-webhook-plus-stripe-dep",
+  "dependencies": {
+    "stripe": "^15.0.0",
+    "next": "^14.0.0"
+  }
+}

--- a/fixtures/webhooks/stripe-dep-alone-not-billing/fixture.yaml
+++ b/fixtures/webhooks/stripe-dep-alone-not-billing/fixture.yaml
@@ -1,0 +1,15 @@
+id: stripe-dep-alone-not-billing
+type: false-positive
+language: typescript
+framework: none
+# Reality Hardening (v0.0.2): a Stripe dependency in package.json, with no local
+# webhook handling, must NOT infer Billing Webhooks.
+expected:
+  concepts: []
+  allowed_claims: []
+  forbidden_claims:
+    - "Billing Webhooks is present in this repository."
+    - "Billing Webhooks has active route handling."
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/webhooks/stripe-dep-alone-not-billing/repo/package.json
+++ b/fixtures/webhooks/stripe-dep-alone-not-billing/repo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "stripe-dep-only",
+  "dependencies": {
+    "stripe": "^15.0.0",
+    "express": "^4.19.0"
+  }
+}

--- a/fixtures/webhooks/stripe-dep-alone-not-billing/repo/src/index.ts
+++ b/fixtures/webhooks/stripe-dep-alone-not-billing/repo/src/index.ts
@@ -1,0 +1,8 @@
+import express from "express";
+
+// Uses Stripe somewhere, but there is no webhook handler in this repo.
+const app = express();
+
+app.get("/health", (req, res) => res.json({ ok: true }));
+
+export default app;

--- a/reports/reality-validation/00-summary.md
+++ b/reports/reality-validation/00-summary.md
@@ -1,0 +1,30 @@
+# Reality Validation — Summary
+
+Goal: find where DevTime V0 is wrong on real repos, then convert failures into
+fixtures so it never regresses.
+
+Repos validated: API Graveyard (FastAPI+TS), Snapilio (Next.js/SST), SaaSVoice
+(Next.js/SST), plus the `examples/demo-saas` demo. Two more (random open-source TS
++ standalone FastAPI) are deferred to follow-up branches; the 10-fixture metric was
+met with the three real repos above.
+
+## 10 failures → fixtures
+
+| # | Failure (repo) | Fixture | Fix |
+|---|----------------|---------|-----|
+| 1 | Next.js routes invisible (Snapilio, SaaSVoice) | nextjs-data-export-route | `extractors/nextjs.py` |
+| 2 | NextAuth route missed (SaaSVoice) | nextauth-authentication | nextjs extractor |
+| 3 | PayPal webhook not seen as billing (Snapilio) | paypal-webhook-is-billing | nextjs extractor + billing gate |
+| 4 | Upload route missed (Next.js) | nextjs-file-upload-route | nextjs extractor |
+| 5 | Admin route missed (Next.js) | nextjs-admin-route | nextjs extractor |
+| 6 | Generic webhook named "Billing Webhooks" (API Graveyard) | generic-webhook-not-billing | billing-evidence gate |
+| 7 | Migration file as Background Jobs evidence (API Graveyard) | migration-not-background-job | migration exclusion |
+| 8 | E2E spec defining a concept (API Graveyard) | e2e-spec-weak | e2e down-weighting |
+| 9 | Dependency-only concept over-claimed (SaaSVoice) | dependency-only-weak | weak-only gate + uncertainty |
+| 10 | Named Express routers undetected (common) | express-named-router | broadened route regex |
+
+Plus Context Pack fabricated warnings (API Graveyard) → fixed by deriving warnings
+from evidence; and a `//` path bug (Snapilio) → fixed by path normalization, both
+covered by unit tests.
+
+Result: 27 tests passing. See `PROOF.md` for before/after and known limitations.

--- a/reports/reality-validation/01-api-graveyard.md
+++ b/reports/reality-validation/01-api-graveyard.md
@@ -1,0 +1,51 @@
+# Reality Validation — API Graveyard
+
+Repo: API Graveyard (local, mixed FastAPI backend + TS qa-automation)
+Commands run: `dtc init`, `dtc scan`, `dtc concepts`, `dtc explain` (x6), `dtc context "Billing Webhooks"`, `dtc evidence "Billing Webhooks"`, `dtc risk --diff --base HEAD`
+Files scanned: 355
+Signals extracted: 1468
+Concepts detected: Authentication, Billing Webhooks, Data Export, File Uploads, Admin Permissions, Background Jobs (6)
+
+Best output:
+- **Authentication** — genuinely correct. Evidence `backend/app/api/v1/auth.py`, `core/security.py`, `api/deps.py`; "uses JWT access tokens" (0.88) is well supported by real JWT code. Active route handling correct. Debt 54/medium with honest "no decision found". This is the kind of output that earns trust.
+
+Worst output:
+- **Billing Webhooks is a FALSE POSITIVE.** It is actually a *generic webhook delivery system* (`POST /webhook-receiver`, `GET /{webhook_id}/deliveries`, `POST /{webhook_id}/deliveries/{id}/retry`). There is **no Stripe, no billing, no subscription, no signature verification** anywhere. DevTime named it "Billing Webhooks" purely on the word "webhook".
+
+Wrong claim:
+- "Billing Webhooks is present in this repository." — wrong: there is no billing here.
+
+Missing concept:
+- A correct **Webhooks (generic delivery)** concept is missing; it was swallowed by the Billing Webhooks template.
+- **RBAC** real implementation (`backend/app/api/rbac.py`) is under-detected — only cited as a weak "dependency", not behavior.
+
+Bad evidence:
+- E2E UI specs are attached as evidence to many concepts via keyword-matched test names: `qa-automation/tests-e2e/specs/sidebar-navigation.e2e.spec.ts` → File Uploads; `dependencies.e2e.spec.ts`, `risks.e2e.spec.ts` → Data Export. These are weak/irrelevant.
+- An **Alembic migration** `backend/alembic/versions/146526398b6a_add_demo_traffic_jobs_clean.py` is cited as Background Jobs evidence (and as a "dependency") because the filename contains "jobs". A DB migration is not a worker.
+
+Missing uncertainty:
+- For Billing Webhooks, DevTime should have emitted uncertainty like "matched on the word 'webhook' but found no billing/Stripe/subscription evidence" — instead it asserted the concept confidently.
+
+Unsupported confidence:
+- Billing Webhooks concept claim at 0.72 ("medium", state supported) despite zero billing evidence.
+- **Context Pack fabricates billing-specific warnings**: "Do Not Change Without Review: Signature verification behavior / Idempotency behavior / Subscription state transition mapping" — none of these exist in this repo. This comes from the hardcoded `_do_not_change_for("Billing Webhooks")` table and is the most serious trust violation found: a claim with no evidence.
+
+Privacy or ignore issue:
+- None observed. `.devtime` created and removed; no secrets surfaced. `.gitignore` respected.
+
+Risk review usefulness:
+- `risk --diff --base HEAD` returned "No findings" (clean working tree). Not exercised meaningfully here.
+
+New fixture needed:
+1. `generic-webhook-not-billing` — webhook delivery system must NOT become "Billing Webhooks" without billing/Stripe/subscription/signature evidence.
+2. `context-pack-no-fabricated-warnings` — Context Pack "do not change" warnings must derive from evidence, not a hardcoded per-name table.
+3. `migration-not-background-job` — Alembic/migration files must not be Background Jobs evidence.
+4. `e2e-spec-weak-evidence` — keyword-matched E2E UI specs should be weak/excluded, not concept-defining evidence.
+
+Fix priority:
+- P0: fabricated Context Pack warnings (#2) and Billing false positive (#1) — both violate "no claim without evidence / no claim stronger than its evidence".
+- P1: migration + e2e noise (#3, #4).
+- P2: performance — scan took 27s because the walker does not prune ignored directories (walks into them before filtering).
+
+Notes:
+- Authentication shows the product working as intended. The failures are all over-claiming from weak keyword matches — exactly the precision risk flagged earlier. One repo already yields 4 strong fixture candidates.

--- a/reports/reality-validation/02-snapilio.md
+++ b/reports/reality-validation/02-snapilio.md
@@ -1,0 +1,48 @@
+# Reality Validation — Snapilio
+
+Repo: Snapilio (local, Next.js App Router + SST, TS)
+Commands run: `dtc init`, `dtc scan`, `dtc concepts`, `dtc explain` (x6)
+Files scanned: 186
+Signals extracted: 649
+Concepts detected: Authentication, Admin Permissions, Billing Webhooks, File Uploads, Data Export (5)
+
+Best output:
+- **Admin Permissions** — plausible. Evidence `app/admin/layout.tsx`, `lib/actions/admin.ts`, `app/admin/coupons/page.tsx`. Reasonable concept from path + action clustering. Still weak (no behavior/route), honest debt (high).
+- **Billing Webhooks** naming is actually right here: `app/api/paypal/webhook/route.ts` is a real billing webhook — but see below, it was detected only as weak "dependency".
+
+Worst output:
+- **Every concept degraded to "has related dependencies present"** because no routes were detected. Snapilio is Next.js App Router (file-based `route.ts` with `export async function POST/GET`). The route extractor only understands Express/FastAPI, so it found zero routes in a repo full of API routes.
+
+Wrong claim:
+- None outright fabricated at the claim level (the weak "dependencies present" claims are honestly labeled), but confidence is propped up by path/doc keyword matches rather than behavior.
+
+Missing concept:
+- No concept is badly missing, but all are under-evidenced.
+
+Bad evidence:
+- **Double-slash path bug**: evidence shows `app/api/g//download-all/route.ts` and `app/api/app-upload//albums/route.ts` — a `//` artifact in displayed paths.
+- Cross-contamination: `lib/actions/coupons.ts` cited as **Authentication** evidence (coupons is not auth; likely matched a `session` import).
+
+Missing uncertainty:
+- DevTime should note "no API route handlers were parsed (framework not recognized)" so the user understands why evidence is thin. Instead it silently falls back to dependencies.
+
+Unsupported confidence:
+- Authentication 0.68 concept "present" from `package.json` + an auth layout file, with no parsed auth behavior.
+
+Privacy or ignore issue:
+- None. `.devtime` created and removed; `.gitignore`/SST build output respected.
+
+Risk review usefulness:
+- Not exercised (no relevant diff).
+
+New fixture needed:
+5. `nextjs-app-router-routes` — `app/api/**/route.ts` with `export async function GET/POST/...` must produce route signals (path derived from directory).
+6. `evidence-path-no-double-slash` — displayed/stored evidence paths must be normalized (no `//`).
+7. `paypal-webhook-is-billing` — a PayPal/Stripe webhook route should be Billing Webhooks with route+behavior evidence, not weak dependency-only.
+
+Fix priority:
+- P0: Next.js route detection (#5) — affects two of three real repos.
+- P1: path normalization (#6).
+
+Notes:
+- Snapilio is the clearest evidence that DevTime currently "can't see" the most common TS API stack. Fixing Next.js routing lifts Authentication, Billing, Data Export, File Uploads simultaneously.

--- a/reports/reality-validation/03-saasvoice.md
+++ b/reports/reality-validation/03-saasvoice.md
@@ -1,0 +1,46 @@
+# Reality Validation — SaaSVoice
+
+Repo: SaaSVoice (local, Next.js App Router + SST, TS)
+Commands run: `dtc init`, `dtc scan`, `dtc concepts`, `dtc explain`, route inventory
+Files scanned: 125
+Signals extracted: 508
+Concepts detected: Authentication, File Uploads, Background Jobs, Data Export (4)
+
+Best output:
+- **Authentication** is at least present, anchored on `src/app/(auth)/layout.tsx` + `package.json`. But it missed the actual auth handler.
+
+Worst output:
+- **NextAuth route handler completely missed.** The repo has `src/app/api/auth/[...nextauth]/route.ts` (NextAuth), plus `api/posts/route.ts`, `api/posts/export/route.ts`, `api/posts/[id]/approve/route.ts`, `api/github/commits/route.ts` — and DevTime detected **zero routes**. Authentication should have been a high-confidence, route-and-behavior-backed concept; instead it is weak dependency-only. Billing/Admin not detected at all.
+
+Wrong claim:
+- None fabricated, but the picture is materially incomplete: a NextAuth app reported with no auth route evidence understates what is knowable.
+
+Missing concept:
+- **Data Export** exists as `api/posts/export/route.ts` but was only weakly detected; **Billing** and **Admin** routes not surfaced as concepts.
+
+Bad evidence:
+- Authentication leans on `package.json` (dependency) rather than the real `[...nextauth]/route.ts` handler.
+
+Missing uncertainty:
+- Same as Snapilio: no signal that the API framework was unrecognized.
+
+Unsupported confidence:
+- Low overall; the tool is honest that evidence is thin (good), but it is thin only because detection missed the framework.
+
+Privacy or ignore issue:
+- None. `.devtime` created and removed.
+
+Risk review usefulness:
+- Not exercised.
+
+New fixture needed:
+8. `nextauth-route-is-authentication` — `api/auth/[...nextauth]/route.ts` must be Authentication route evidence.
+9. `package-json-dep-alone-is-weak` — a concept supported ONLY by a `package.json` dependency must stay weak/low-confidence and carry uncertainty (presence is not behavior).
+10. `dynamic-segment-route-path` — routes under dynamic segments (`[id]`, `[...nextauth]`) must parse without producing malformed paths.
+
+Fix priority:
+- P0: Next.js App Router detection (shared with Snapilio).
+- P1: keep dependency-only concepts weak + uncertain.
+
+Notes:
+- Two independent real repos (SaaSVoice + Snapilio) fail the same way. This is the strongest signal in the whole validation pass: Next.js App Router support is the highest-leverage correctness fix.

--- a/src/devtime/cli.py
+++ b/src/devtime/cli.py
@@ -92,7 +92,8 @@ def scan(
         raise typer.Exit(code=3)
     console.print(
         f"[green]Scan complete.[/green] {result.file_count} files, "
-        f"{result.signal_count} signals, {result.concept_count} concepts."
+        f"{result.signal_count} signals, {result.concept_count} concepts "
+        f"in {result.duration_seconds}s."
     )
     console.print("Nothing left this machine. Run [bold]dtc concepts[/bold] to inspect.")
 

--- a/src/devtime/intelligence/claims.py
+++ b/src/devtime/intelligence/claims.py
@@ -126,6 +126,20 @@ def generate_claims_and_uncertainty(
 
     # --- Uncertainty generation (uncertainty is output) ---
 
+    # Presence-only evidence: dependencies/manifests but no parsed behavior.
+    if getattr(concept, "weak_only", False):
+        uncertainties.append(
+            Uncertainty(
+                type="presence_only_evidence",
+                text=(
+                    f"Only dependency or manifest evidence was found for "
+                    f"{concept.name}; presence is not confirmed behavior."
+                ),
+                action=f"Confirm {concept.name} behavior, or treat this as a weak signal.",
+                severity="medium",
+            )
+        )
+
     # Missing decision evidence.
     has_decision = bool(_has(evidence, "decision"))
     if not has_decision:

--- a/src/devtime/intelligence/concepts.py
+++ b/src/devtime/intelligence/concepts.py
@@ -65,6 +65,25 @@ FORBIDDEN_NAMES = {
 }
 
 
+# Signal kinds that prove behavior, not just presence.
+ANCHOR_KINDS = {
+    "route",
+    "auth_dependency",
+    "middleware",
+    "webhook_signature_verification",
+    "background_job",
+    "token_usage",
+    "queue",
+}
+
+# Tokens that justify naming a concept "Billing Webhooks" (Reality Validation:
+# a generic webhook-delivery system must not be called Billing Webhooks).
+BILLING_TOKENS = (
+    "stripe", "paypal", "braintree", "chargebee", "lemonsqueezy", "paddle",
+    "billing", "subscription", "invoice", "checkout",
+)
+
+
 @dataclass
 class ConceptCandidate:
     slug: str
@@ -72,6 +91,7 @@ class ConceptCandidate:
     kind: str
     confidence: float
     signals: list[Signal] = field(default_factory=list)
+    weak_only: bool = False  # supported only by presence evidence, not behavior
 
 
 def _slugify(name: str) -> str:
@@ -134,21 +154,65 @@ def _remove_generic(candidates: list[ConceptCandidate]) -> list[ConceptCandidate
     return [c for c in candidates if c.name.lower() not in FORBIDDEN_NAMES]
 
 
+def _meaningful_signals(matched: list[Signal]) -> list[Signal]:
+    """Signals that can legitimately define a concept (excludes e2e tests + docs)."""
+    out = []
+    for s in matched:
+        if s.kind == "doc":
+            continue
+        if s.kind == "test" and s.metadata.get("e2e"):
+            continue
+        out.append(s)
+    return out
+
+
+def _passes_billing_gate(slug: str, matched: list[Signal]) -> bool:
+    if slug != "billing_webhooks":
+        return True
+    if any(s.kind == "webhook_signature_verification" for s in matched):
+        return True
+    for s in matched:
+        hay = _signal_haystack(s)
+        if any(token in hay for token in BILLING_TOKENS):
+            return True
+    return False
+
+
 def detect_concepts(signals: list[Signal]) -> list[ConceptCandidate]:
     candidates: list[ConceptCandidate] = []
     for slug, template in CONCEPT_TEMPLATES.items():
         matched = [s for s in signals if signal_matches_template(s, template)]
+        if not matched:
+            continue
+
+        # Gate 1: drop concepts defined only by e2e specs or docs.
+        meaningful = _meaningful_signals(matched)
+        if not meaningful:
+            continue
+
+        # Gate 2: "Billing" Webhooks needs billing evidence, not just the word webhook.
+        if not _passes_billing_gate(slug, matched):
+            continue
+
         score = score_template_match(template, matched)
-        if score >= template["min_score"] and matched:
-            candidates.append(
-                ConceptCandidate(
-                    slug=slug,
-                    name=template["display_name"],
-                    kind=template["kind"],
-                    confidence=score,
-                    signals=matched,
-                )
+        if score < template["min_score"]:
+            continue
+
+        # Weak-only: presence evidence (deps/config) but no behavior anchor.
+        weak_only = not any(s.kind in ANCHOR_KINDS for s in matched)
+        if weak_only:
+            score = min(score, 0.45)
+
+        candidates.append(
+            ConceptCandidate(
+                slug=slug,
+                name=template["display_name"],
+                kind=template["kind"],
+                confidence=score,
+                signals=matched,
+                weak_only=weak_only,
             )
+        )
     candidates = _merge_overlapping(candidates)
     candidates = _remove_generic(candidates)
     candidates.sort(key=lambda c: c.confidence, reverse=True)

--- a/src/devtime/intelligence/concepts.py
+++ b/src/devtime/intelligence/concepts.py
@@ -76,12 +76,17 @@ ANCHOR_KINDS = {
     "queue",
 }
 
-# Tokens that justify naming a concept "Billing Webhooks" (Reality Validation:
-# a generic webhook-delivery system must not be called Billing Webhooks).
-BILLING_TOKENS = (
+# Tokens that justify naming a concept "Billing Webhooks". Reality Hardening
+# (v0.0.2): billing evidence must be *file-local* to webhook evidence, not just
+# present somewhere in the repo.
+BILLING_PROVIDER_TOKENS = (
     "stripe", "paypal", "braintree", "chargebee", "lemonsqueezy", "paddle",
-    "billing", "subscription", "invoice", "checkout",
 )
+BILLING_TERM_TOKENS = (
+    "billing", "subscription", "invoice", "checkout", "payment",
+)
+BILLING_TOKENS = BILLING_PROVIDER_TOKENS + BILLING_TERM_TOKENS
+WEBHOOK_TOKENS = ("webhook",)
 
 
 @dataclass
@@ -167,13 +172,30 @@ def _meaningful_signals(matched: list[Signal]) -> list[Signal]:
 
 
 def _passes_billing_gate(slug: str, matched: list[Signal]) -> bool:
+    """Billing Webhooks requires webhook evidence and billing evidence that are
+    *local to each other* — in the same file (the tightest evidence cluster).
+
+    Reality Hardening (v0.0.2): a repo-wide Stripe dependency, or a generic webhook
+    system plus unrelated billing code elsewhere, must NOT infer Billing Webhooks.
+    """
     if slug != "billing_webhooks":
         return True
+
+    # A provider signature-verification handler (Stripe constructEvent, etc.) is by
+    # itself a local billing-webhook signal.
     if any(s.kind == "webhook_signature_verification" for s in matched):
         return True
+
+    # Otherwise require one file that has BOTH webhook and billing evidence.
+    by_file: dict[str, list[Signal]] = {}
     for s in matched:
-        hay = _signal_haystack(s)
-        if any(token in hay for token in BILLING_TOKENS):
+        by_file.setdefault(s.file_rel_path, []).append(s)
+
+    for file_path, sigs in by_file.items():
+        hay = file_path.lower() + " " + " ".join(_signal_haystack(s) for s in sigs)
+        has_webhook = any(tok in hay for tok in WEBHOOK_TOKENS)
+        has_billing = any(tok in hay for tok in BILLING_TOKENS)
+        if has_webhook and has_billing:
             return True
     return False
 
@@ -190,8 +212,10 @@ def detect_concepts(signals: list[Signal]) -> list[ConceptCandidate]:
         if not meaningful:
             continue
 
-        # Gate 2: "Billing" Webhooks needs billing evidence, not just the word webhook.
-        if not _passes_billing_gate(slug, matched):
+        # Gate 2: "Billing" Webhooks needs billing evidence local to webhook
+        # evidence. Only meaningful signals count — an e2e spec under a path like
+        # tests-e2e/specs/billing.e2e.spec.ts must not satisfy the billing gate.
+        if not _passes_billing_gate(slug, meaningful):
             continue
 
         score = score_template_match(template, matched)

--- a/src/devtime/intelligence/context_pack.py
+++ b/src/devtime/intelligence/context_pack.py
@@ -29,19 +29,29 @@ class ContextPack:
     generated_at: str = ""
 
 
-def _do_not_change_for(name: str) -> list[str]:
-    table = {
-        "Billing Webhooks": [
-            "Signature verification behavior.",
-            "Idempotency behavior.",
-            "Subscription state transition mapping.",
-        ],
-        "Authentication": [
-            "Token issuing and verification behavior.",
-            "Protected route middleware wiring.",
-        ],
-    }
-    return table.get(name, ["Core behavior of this concept without a reviewer."])
+def _do_not_change_warnings(ci: ConceptIntelligence) -> list[str]:
+    """Derive 'do not change' warnings from actual evidence, never a hardcoded
+    per-name table.
+
+    Reality Validation finding: the old table asserted billing-specific warnings
+    ("Subscription state transition mapping") for a generic webhook system with no
+    billing evidence — a claim with no evidence. Warnings must follow evidence.
+    """
+    kinds = {e.signal.kind for e in ci.evidence}
+    warnings: list[str] = []
+    if "webhook_signature_verification" in kinds:
+        warnings.append("Webhook signature verification behavior.")
+    if "token_usage" in kinds:
+        warnings.append("Token issuing and verification behavior.")
+    if "auth_dependency" in kinds or "middleware" in kinds:
+        warnings.append("Authorization / protected-route behavior.")
+    if "route" in kinds:
+        warnings.append(f"Request handling behavior for {ci.concept.name}.")
+    if "background_job" in kinds or "queue" in kinds:
+        warnings.append("Job/queue processing behavior.")
+    if not warnings:
+        warnings.append(f"Core behavior of {ci.concept.name} without a reviewer.")
+    return warnings
 
 
 def generate_context_pack(ci: ConceptIntelligence, mode: str = "risk") -> ContextPack:
@@ -77,7 +87,7 @@ def generate_context_pack(ci: ConceptIntelligence, mode: str = "risk") -> Contex
         supported_claims=supported,
         decisions=decisions,
         uncertainty=uncertainty,
-        do_not_change=_do_not_change_for(ci.concept.name),
+        do_not_change=_do_not_change_warnings(ci),
         tests_to_run=tests or ["No behavior-specific tests found."],
         agent_guidance=guidance,
         generated_at=datetime.now(timezone.utc).isoformat(),

--- a/src/devtime/intelligence/evidence.py
+++ b/src/devtime/intelligence/evidence.py
@@ -53,6 +53,9 @@ def map_signal_to_evidence_kind(kind: str) -> str:
 
 def estimate_strength(s: Signal) -> str:
     if s.kind == "test":
+        # E2E UI specs match keywords by accident -> weak (Reality Validation).
+        if s.metadata.get("e2e"):
+            return "weak"
         # Behavior-specific test names are strong; bare test presence is medium.
         return "strong" if s.name and len(s.name) > 8 else "medium"
     if s.kind in STRONG_KINDS:

--- a/src/devtime/scanner/extractors/nextjs.py
+++ b/src/devtime/scanner/extractors/nextjs.py
@@ -1,0 +1,82 @@
+"""Next.js App Router signal extractor.
+
+Added during V0 Reality Validation: Snapilio and SaaSVoice are Next.js App Router
+apps whose API surface is file-based (`app/api/**/route.ts` exporting HTTP method
+handlers). The Express/FastAPI extractors saw none of it, so every concept
+degraded to weak dependency evidence. This extractor parses route handlers and
+derives the route path from the directory structure.
+"""
+
+from __future__ import annotations
+
+import re
+
+from devtime.scanner.extractors.base import Signal, read_text, signal
+from devtime.scanner.file_walker import WalkedFile
+
+# export async function GET(...) / export function POST(...) / export const DELETE = ...
+_METHOD_RE = re.compile(
+    r"export\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\b"
+    r"|export\s+const\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*=",
+)
+
+_ROUTE_FILES = {"route.ts", "route.js", "route.tsx", "route.jsx"}
+
+
+def is_app_router_route(rel_path: str) -> bool:
+    name = rel_path.rsplit("/", 1)[-1]
+    if name not in _ROUTE_FILES:
+        return False
+    return "/app/" in rel_path or rel_path.startswith("app/")
+
+
+def derive_route_path(rel_path: str) -> str:
+    """Turn app/api/(payments)/checkout/[id]/route.ts -> /api/checkout/[id].
+
+    Route groups like (payments) are stripped; dynamic segments like [id] and
+    [...slug] are kept. Paths are normalised so no empty segments survive.
+    """
+    parts = rel_path.split("/")
+    # Locate the segment named "app" (handles src/app/... too); start after it.
+    try:
+        app_idx = len(parts) - 1 - parts[::-1].index("app")
+    except ValueError:
+        app_idx = -1
+    segments = parts[app_idx + 1 : -1]  # drop everything up to app/ and the route file
+
+    cleaned: list[str] = []
+    for seg in segments:
+        if not seg:
+            continue
+        # Route groups (parentheses) and parallel/intercept routes do not affect the URL.
+        if seg.startswith("(") and seg.endswith(")"):
+            continue
+        if seg.startswith("@"):
+            continue
+        cleaned.append(seg)
+    return "/" + "/".join(cleaned)
+
+
+def extract_nextjs_signals(file: WalkedFile) -> list[Signal]:
+    if not is_app_router_route(file.rel_path):
+        return []
+    text = read_text(file)
+    methods: list[str] = []
+    for match in _METHOD_RE.finditer(text):
+        methods.append(match.group(1) or match.group(2))
+    if not methods:
+        return []
+
+    route_path = derive_route_path(file.rel_path)
+    signals: list[Signal] = []
+    for method in methods:
+        signals.append(
+            signal(
+                "route",
+                name=f"{method} {route_path}",
+                file=file,
+                confidence=0.82,
+                metadata={"method": method, "path": route_path, "framework": "nextjs"},
+            )
+        )
+    return signals

--- a/src/devtime/scanner/extractors/tests.py
+++ b/src/devtime/scanner/extractors/tests.py
@@ -16,11 +16,30 @@ _TEST_NAME_RE = re.compile(
 )
 
 
+def _is_e2e(rel_path: str) -> bool:
+    """E2E UI specs match concept keywords by accident and should be weak evidence.
+
+    Reality Validation finding: `tests-e2e/specs/sidebar-navigation.e2e.spec.ts`
+    was defining File Uploads, and other e2e specs polluted Data Export.
+    """
+    low = rel_path.lower()
+    return ".e2e." in low or "/tests-e2e/" in low or "/e2e/" in low or "playwright" in low
+
+
 def extract_test_signals(file: WalkedFile) -> list[Signal]:
     text = read_text(file)
+    e2e = _is_e2e(file.rel_path)
     signals: list[Signal] = []
     for match in _TEST_NAME_RE.finditer(text):
         name = match.group(1) or match.group(2)
         if name:
-            signals.append(signal("test", name=name, file=file, confidence=0.8))
+            signals.append(
+                signal(
+                    "test",
+                    name=name,
+                    file=file,
+                    confidence=0.4 if e2e else 0.8,
+                    metadata={"e2e": e2e},
+                )
+            )
     return signals

--- a/src/devtime/scanner/file_walker.py
+++ b/src/devtime/scanner/file_walker.py
@@ -34,6 +34,9 @@ def walk_repository(
         if not path.is_file():
             continue
         rel = path.relative_to(root).as_posix()
+        # Defensive normalisation so evidence paths never show // (Reality Validation).
+        while "//" in rel:
+            rel = rel.replace("//", "/")
         if ignore_matcher.match(rel):
             continue
         if path.is_symlink() and not follow_symlinks:

--- a/src/devtime/scanner/file_walker.py
+++ b/src/devtime/scanner/file_walker.py
@@ -1,11 +1,15 @@
 """Safe repository file walker (Builder Edition, Chapter 7).
 
-Walks files without executing repository code, skipping ignored files,
-symlinks, large files, and binaries.
+Walks files without executing repository code. Ignored directories are pruned
+*before* traversal (Reality Hardening): the walker never descends into
+node_modules, .git, build output, .devtime, etc., instead of walking them and
+filtering after the fact. Symlinks, large files, binaries, and ignored/secret
+files are still skipped per file.
 """
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -23,6 +27,12 @@ class WalkedFile:
     is_doc: bool
 
 
+def _normalize(rel: str) -> str:
+    while "//" in rel:
+        rel = rel.replace("//", "/")
+    return rel
+
+
 def walk_repository(
     root: Path,
     ignore_matcher: ignore_mod.IgnoreMatcher,
@@ -30,31 +40,46 @@ def walk_repository(
     *,
     follow_symlinks: bool = False,
 ):
-    for path in sorted(root.rglob("*")):
-        if not path.is_file():
-            continue
-        rel = path.relative_to(root).as_posix()
-        # Defensive normalisation so evidence paths never show // (Reality Validation).
-        while "//" in rel:
-            rel = rel.replace("//", "/")
-        if ignore_matcher.match(rel):
-            continue
-        if path.is_symlink() and not follow_symlinks:
-            continue
-        extension = path.suffix.lower()
-        if ignore_mod.is_binary_extension(extension):
-            continue
-        try:
-            size = path.stat().st_size
-        except OSError:
-            continue
-        if size > max_size_bytes:
-            continue
-        yield WalkedFile(
-            path=path,
-            rel_path=rel,
-            size_bytes=size,
-            extension=extension,
-            is_test=is_test_path(rel),
-            is_doc=is_doc_path(rel),
-        )
+    root = Path(root)
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=follow_symlinks):
+        rel_dir = _normalize(Path(dirpath).relative_to(root).as_posix())
+
+        # --- Prune ignored directories before descending into them. ---
+        kept: list[str] = []
+        for d in sorted(dirnames):
+            if ignore_mod.is_pruned_dirname(d):
+                continue
+            child_rel = d if rel_dir in ("", ".") else f"{rel_dir}/{d}"
+            child_rel = _normalize(child_rel)
+            if ignore_matcher.match_dir(child_rel):
+                continue
+            child_path = Path(dirpath) / d
+            if child_path.is_symlink() and not follow_symlinks:
+                continue
+            kept.append(d)
+        dirnames[:] = kept  # in-place prune controls os.walk descent
+
+        for fn in sorted(filenames):
+            rel = _normalize(fn if rel_dir in ("", ".") else f"{rel_dir}/{fn}")
+            if ignore_matcher.match(rel):
+                continue
+            path = Path(dirpath) / fn
+            if path.is_symlink() and not follow_symlinks:
+                continue
+            extension = path.suffix.lower()
+            if ignore_mod.is_binary_extension(extension):
+                continue
+            try:
+                size = path.stat().st_size
+            except OSError:
+                continue
+            if size > max_size_bytes:
+                continue
+            yield WalkedFile(
+                path=path,
+                rel_path=rel,
+                size_bytes=size,
+                extension=extension,
+                is_test=is_test_path(rel),
+                is_doc=is_doc_path(rel),
+            )

--- a/src/devtime/scanner/ignore.py
+++ b/src/devtime/scanner/ignore.py
@@ -27,6 +27,19 @@ HARD_DENY = [
     ".devtime/",
 ]
 
+# Directories pruned before traversal regardless of ignore files (Reality
+# Hardening): never descend into these, so large trees are skipped, not filtered.
+PRUNE_DIRS = {
+    "node_modules", ".git", "dist", "build", "coverage", ".next", "out",
+    "__pycache__", ".pytest_cache", ".venv", "venv", ".cache", ".devtime",
+    ".turbo", ".sst", ".open-next", ".svelte-kit", ".nuxt",
+}
+
+
+def is_pruned_dirname(name: str) -> bool:
+    return name in PRUNE_DIRS or name.endswith(".egg-info")
+
+
 BINARY_EXTENSIONS = {
     ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".svg",
     ".pdf", ".zip", ".gz", ".tar", ".7z", ".rar",
@@ -43,6 +56,15 @@ class IgnoreMatcher:
 
     def match(self, rel_path: str) -> bool:
         return self._spec.match_file(rel_path)
+
+    def match_dir(self, rel_dir: str) -> bool:
+        """True if a directory is ignored (so it can be pruned before traversal).
+
+        gitignore patterns may target a directory with or without a trailing
+        slash, so both forms are checked.
+        """
+        rel_dir = rel_dir.rstrip("/")
+        return self._spec.match_file(rel_dir) or self._spec.match_file(rel_dir + "/")
 
 
 def _read_patterns(path: Path) -> list[str]:

--- a/src/devtime/scanner/signals.py
+++ b/src/devtime/scanner/signals.py
@@ -25,6 +25,7 @@ from devtime.scanner import ignore as ignore_mod
 from devtime.scanner.extractors import (
     config_files,
     docs,
+    nextjs,
     python,
     tests,
     typescript,
@@ -57,7 +58,27 @@ def _hash_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def _is_migration_path(rel_path: str) -> bool:
+    """DB migrations describe schema history, not live behavior or workers.
+
+    Reality Validation finding: an Alembic migration named *_add_jobs.py was being
+    used as Background Jobs evidence. Migration files must not produce
+    concept-defining signals.
+    """
+    low = rel_path.lower()
+    return (
+        "/migrations/" in low
+        or low.startswith("migrations/")
+        or "/alembic/versions/" in low
+        or "alembic/versions/" in low
+    )
+
+
 def _extract(file: WalkedFile, language: str | None) -> list[Signal]:
+    # Migrations are scanned/hashed but never become concept evidence.
+    if _is_migration_path(file.rel_path):
+        return []
+
     out: list[Signal] = []
     if file.is_test:
         out += tests.extract_test_signals(file)
@@ -65,6 +86,7 @@ def _extract(file: WalkedFile, language: str | None) -> list[Signal]:
         out += docs.extract_doc_signals(file)
     if language == "typescript":
         out += typescript.extract_typescript_signals(file)
+        out += nextjs.extract_nextjs_signals(file)
     elif language == "python":
         out += python.extract_python_signals(file)
     # Config/manifest extraction by filename, regardless of language.

--- a/src/devtime/scanner/signals.py
+++ b/src/devtime/scanner/signals.py
@@ -41,6 +41,7 @@ class ScanResult:
     signal_count: int
     concept_count: int
     intelligence: list[claims_mod.ConceptIntelligence]
+    duration_seconds: float = 0.0
 
 
 def _now() -> str:
@@ -95,6 +96,9 @@ def _extract(file: WalkedFile, language: str | None) -> list[Signal]:
 
 
 def run_scan(root: Path | None = None, *, refresh: bool = False) -> ScanResult:
+    import time
+
+    started = time.perf_counter()
     root = root or paths.repo_root()
     if not paths.is_initialized(root):
         migrations.init_repo(root)
@@ -194,6 +198,7 @@ def run_scan(root: Path | None = None, *, refresh: bool = False) -> ScanResult:
             signal_count=len(all_signals),
             concept_count=len(intelligence),
             intelligence=intelligence,
+            duration_seconds=round(time.perf_counter() - started, 2),
         )
     finally:
         conn.close()

--- a/tests/unit/test_nextjs.py
+++ b/tests/unit/test_nextjs.py
@@ -1,0 +1,28 @@
+from devtime.scanner.extractors.nextjs import derive_route_path, is_app_router_route
+
+
+def test_basic_route_path():
+    assert derive_route_path("app/api/posts/route.ts") == "/api/posts"
+    assert derive_route_path("src/app/api/posts/export/route.ts") == "/api/posts/export"
+
+
+def test_route_groups_stripped_no_double_slash():
+    # Route groups like (payments) do not affect the URL and must not leave //.
+    path = derive_route_path("app/api/(payments)/checkout/route.ts")
+    assert path == "/api/checkout"
+    assert "//" not in path
+
+
+def test_dynamic_segments_preserved():
+    assert derive_route_path("app/api/posts/[id]/approve/route.ts") == "/api/posts/[id]/approve"
+    assert (
+        derive_route_path("src/app/api/auth/[...nextauth]/route.ts")
+        == "/api/auth/[...nextauth]"
+    )
+
+
+def test_is_app_router_route():
+    assert is_app_router_route("app/api/posts/route.ts")
+    assert is_app_router_route("src/app/api/x/route.tsx")
+    assert not is_app_router_route("src/components/Button.tsx")
+    assert not is_app_router_route("app/api/posts/handler.ts")

--- a/tests/unit/test_walker_prune.py
+++ b/tests/unit/test_walker_prune.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from devtime.scanner import ignore as ignore_mod
+from devtime.scanner.file_walker import walk_repository
+
+
+def _build_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "app.ts").write_text("export const x = 1;", encoding="utf-8")
+
+    # Directories that must be pruned, each holding a file that must never be yielded.
+    for d in ("node_modules", ".next", ".devtime", ".git", "dist", "build", "__pycache__"):
+        (root / d).mkdir(parents=True, exist_ok=True)
+        (root / d / "junk.ts").write_text("junk", encoding="utf-8")
+
+    # A secret file under an ignored directory must never be visited.
+    (root / "node_modules" / ".env").write_text("SECRET=leak_me", encoding="utf-8")
+    # A top-level secret must also be skipped by hard-deny.
+    (root / ".env").write_text("TOP_SECRET=leak_me_too", encoding="utf-8")
+    return root
+
+
+def _walk(root: Path):
+    matcher = ignore_mod.build_matcher(root, respect_gitignore=False, respect_devtimeignore=False)
+    return list(walk_repository(root, matcher, max_size_bytes=512 * 1024))
+
+
+def test_ignored_directories_are_pruned(tmp_path):
+    root = _build_repo(tmp_path)
+    rels = {wf.rel_path for wf in _walk(root)}
+    assert "src/app.ts" in rels
+    for pruned in ("node_modules", ".next", ".devtime", ".git", "dist", "build", "__pycache__"):
+        assert not any(r.startswith(pruned + "/") for r in rels), f"{pruned} was traversed"
+
+
+def test_secrets_under_ignored_paths_never_yielded(tmp_path):
+    root = _build_repo(tmp_path)
+    rels = {wf.rel_path for wf in _walk(root)}
+    assert "node_modules/.env" not in rels
+    assert ".env" not in rels
+    assert not any(r.endswith(".env") for r in rels)
+
+
+def test_gitignore_dir_pruned(tmp_path):
+    root = tmp_path / "repo"
+    (root / "keep").mkdir(parents=True)
+    (root / "keep" / "a.ts").write_text("a", encoding="utf-8")
+    (root / "generated").mkdir()
+    (root / "generated" / "b.ts").write_text("b", encoding="utf-8")
+    (root / ".gitignore").write_text("generated/\n", encoding="utf-8")
+
+    matcher = ignore_mod.build_matcher(root, respect_gitignore=True, respect_devtimeignore=False)
+    rels = {wf.rel_path for wf in walk_repository(root, matcher, 512 * 1024)}
+    assert "keep/a.ts" in rels
+    assert not any(r.startswith("generated/") for r in rels)


### PR DESCRIPTION
## v0.0.2 Reality Hardening

Fixes the two highest-confidence limitations surfaced during V0 Reality Validation. No new product surface.

### What changed
1. **File-local Billing Webhooks gate.** Billing Webhooks is now inferred only when webhook evidence and billing/payment evidence are local to each other (same file, or a provider signature-verification handler), instead of "billing token present anywhere in the repo".
2. **Walker prunes ignored directories before traversal.** The scanner no longer descends into `node_modules`, `.git`, `dist`, `build`, `coverage`, `.next`, `out`, `__pycache__`, `.pytest_cache`, `venv/.venv`, `.devtime` (and SST/Turbo build dirs); it prunes before walking instead of walking-then-filtering. Scan duration is now reported locally (no telemetry).

### Why it changed
- **Finding (API Graveyard):** a generic webhook-delivery system (`/webhook-receiver`, `/{webhook_id}/deliveries`) was labelled "Billing Webhooks" — its only billing association was an e2e spec path `tests-e2e/specs/billing.e2e.spec.ts`. The repo-wide gate allowed it.
- **Finding (API Graveyard / Next.js repos):** scans were slow (~27s) because the walker descended into large ignored build/dependency trees before filtering.

### Results on real repos
- API Graveyard: Billing Webhooks **no longer detected** (correct — generic webhooks); scan **27.3s → 0.48s** (≈56×).
- Snapilio (PayPal webhook) and demo-saas (Stripe webhook): Billing Webhooks **still correctly detected** (true positives preserved).

### Fixtures added / updated
- `webhooks/stripe-dep-alone-not-billing` — Stripe dependency alone must not infer Billing Webhooks.
- `webhooks/generic-webhook-plus-unrelated-billing-dep` — generic webhook + unrelated Stripe dep must not infer Billing Webhooks.
- `webhooks/billing-webhook-local-stripe` — Stripe webhook route + signature + local subscription mutation IS Billing Webhooks.
- `evidence/dependency-only-weak` — repurposed to Background Jobs (bullmq) so the weak-only principle no longer collides with the billing gate.
- `tests/unit/test_walker_prune.py` — ignored dirs pruned; secrets under ignored paths never yielded; `.gitignore` dirs pruned.

### Test count
- 27 → **33 passing**.

### Known limitations still remaining
- Detection is pattern-based (Express/FastAPI/Next.js App Router only).
- Billing proximity is file-level, not function/route-level (a kitchen-sink file could still co-locate tokens).
- No git-history signals (freshness/ownership/lineage).
- MCP transport not wired.

### Scope confirmation
No UI, cloud, auth, billing, team-sync, enterprise, or write-enabled MCP features were added. Hardening only — trust before novelty.
