### PR TITLE
v0.0.3 public readiness

### DIFF
--- a/CLEAN_INSTALL_CHECK.md
+++ b/CLEAN_INSTALL_CHECK.md
@@ -1,0 +1,51 @@
+# Clean Install Check
+
+A repeatable fresh-clone test: clone, install, test, and run the demo from scratch.
+Use this before any release to confirm a stranger can get from zero to proof.
+
+## Script
+
+```bash
+set -e
+cd /tmp
+rm -rf devtime-clean-test
+git clone https://github.com/Shakargy/devtime.git devtime-clean-test
+cd devtime-clean-test
+
+python -m venv .venv
+source .venv/Scripts/activate        # Windows Git Bash; use .venv/bin/activate on macOS/Linux
+
+pip install -e ".[dev]"
+pytest                               # expect: 33 passed
+
+cd examples/demo-saas
+dtc init
+dtc scan                             # expect: "Scan complete. 15 files, 38 signals, 5 concepts ..."
+dtc concepts
+dtc explain "Billing Webhooks"       # expect: Understanding Debt 56/100 + missing-decision uncertainty
+```
+
+To exercise the advisory risk review, follow the prepared diff in
+[DEMO_SCRIPT.md](DEMO_SCRIPT.md) (edit `src/billing/stripe-webhook.ts`, run
+`dtc risk --diff`, then `git checkout -- src/billing/stripe-webhook.ts`).
+
+## Recorded result
+
+| Field | Result |
+|-------|--------|
+| Date | 2026-06-21 |
+| OS | Windows 11 (Git Bash) |
+| Python | 3.11.9 |
+| Install command | `pip install -e ".[dev]"` |
+| Test result | **33 passed** |
+| `dtc` on PATH | yes (inside the activated venv) |
+| Demo result | scan / concepts / explain produced expected output |
+| Issue found | `dtc risk --diff` reported no findings when the scan root is a subdirectory of the git repo (diff paths were repo-relative, evidence paths scan-root-relative) |
+| Fix | `dtc risk` now runs `git diff --relative`; risk demo verified working |
+
+## Notes
+
+- If `dtc` is "command not found", the virtual environment is not active. Re-activate
+  it, or run `python -m devtime.cli ...`.
+- DevTime scans the **current directory**; always `cd` into the repo (or
+  `examples/demo-saas`) before `dtc init`/`dtc scan`.

--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -1,0 +1,162 @@
+# Demo Script — DevTime V0: Repository Memory From Evidence
+
+A 2–3 minute walkthrough. Every command below is real and copy-pasteable. Run it from
+inside the sample app (`examples/demo-saas`), because DevTime scans the current
+directory.
+
+> Tone: this is **evidence-backed local memory**, not magic. We talk about evidence,
+> uncertainty, local memory, advisory risk review, and the decision loop — never
+> "AI understands your repo", "automatically fixes your code", or "guarantees
+> correctness".
+
+## Setup
+
+```bash
+cd examples/demo-saas
+dtc init
+```
+
+Narration: *"DevTime created a local memory store in `.devtime/`. Nothing leaves this
+machine. No cloud, no telemetry, no code execution."*
+
+## 1. Scan — no execution, no network
+
+```bash
+dtc scan
+```
+
+Output:
+
+```
+Scan complete. 15 files, 38 signals, 5 concepts in 0.1s.
+```
+
+Narration: *"It scanned the repository without running any of its code and without a
+network call, and extracted evidence-backed signals."*
+
+## 2. Concepts — what the repo contains
+
+```bash
+dtc concepts
+```
+
+Narration: *"DevTime found five concepts — Authentication, Billing Webhooks,
+Background Jobs, Data Export, Admin Permissions — each with a confidence level and an
+Understanding Debt score."*
+
+## 3. Authentication — stronger, because there is a decision
+
+```bash
+dtc explain "Authentication"
+```
+
+Narration: *"Authentication is well supported: routes, JWT usage, middleware, tests —
+and a decision record (an ADR). Because the 'why' is documented, its Understanding
+Debt is lower."*
+
+## 4. Billing Webhooks — strong evidence, but real uncertainty
+
+```bash
+dtc explain "Billing Webhooks"
+```
+
+Output includes:
+
+```
+Uncertainty:
+  - No decision was found explaining key choices for Billing Webhooks.
+
+Understanding Debt: 56 / 100 (medium)
+```
+
+Narration: *"Billing Webhooks has strong behavior evidence — a route and Stripe
+signature verification — but DevTime surfaces uncertainty: no decision explains its
+retry or duplicate-delivery behavior. Uncertainty is a feature, not a bug."*
+
+## 5. A risky change is flagged (advisory)
+
+Create the safe demo diff — change retry behavior **without** updating the
+duplicate-delivery test:
+
+```bash
+# edit src/billing/stripe-webhook.ts: wrap the subscription update in a retry loop
+```
+
+Apply this change inside the `customer.subscription.updated` branch (note the word
+"Retry" in the comment — the heuristic keys on it):
+
+```ts
+  if (event.type === "customer.subscription.updated") {
+    // Retry the subscription update a few times on transient failures.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try { await updateSubscriptionState(event.data.object); break; }
+      catch (err) { if (attempt === 2) throw err; }
+    }
+  }
+```
+
+Then:
+
+```bash
+dtc risk --diff
+```
+
+Output:
+
+```
+DevTime Risk Review
+
+Affected concept:
+  Billing Webhooks
+Finding (high):
+  Retry behavior changed without duplicate-delivery test changes.
+Missing:
+  - duplicate-delivery test update
+  - retry strategy decision
+Suggested action:
+  Update duplicate-delivery tests or record the retry behavior decision before merge.
+```
+
+Narration: *"This is advisory, not a gate. DevTime noticed retry behavior changed but
+no duplicate-delivery test was touched — exactly the kind of change worth a second
+look."*
+
+**Revert the demo change:**
+
+```bash
+git checkout -- src/billing/stripe-webhook.ts
+```
+
+## 6. Close the loop — record the decision
+
+```bash
+dtc decision add --concept billing_webhooks \
+  --title "Webhook retry and idempotency strategy" \
+  --body "Retry subscription updates up to 3x; dedupe by Stripe event id."
+
+dtc explain "Billing Webhooks"
+```
+
+Now the uncertainty is gone and Understanding Debt improves:
+
+```
+Uncertainty:
+  (none)
+
+Understanding Debt: 72 / 100 (medium)
+```
+
+Narration: *"We recorded the missing reasoning. Repository memory now contains the
+decision, the uncertainty clears, and Understanding Debt improves from 56 to 72."*
+
+## Close
+
+Narration: *"DevTime is not magic and not an AI agent. It is evidence-backed local
+memory: it shows what the repository can prove, admits what it cannot prove yet, and
+gives humans and agents safer context."*
+
+## Reset (optional)
+
+```bash
+dtc reset            # or: rm -rf .devtime
+```

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,0 +1,82 @@
+# Limitations
+
+DevTime is an early, local-first V0. It is deliberately honest about what it cannot
+do. Read this before trusting any single output.
+
+## 1. Current limitations
+
+- DevTime is a **heuristic scanner**, not a full semantic compiler or type-aware
+  analyzer. It reasons from patterns in code, paths, tests, configs, and docs.
+- It builds **local repository memory** only. There is no cloud, no team sync, and
+  no shared state between machines.
+- There is **no UI**. DevTime is a command-line tool.
+- **Understanding Debt is a product signal, not an objective universal truth.** It is
+  a useful, explainable heuristic for "how well can this concept be explained from
+  evidence?" — not a grade of code quality.
+
+## 2. Accuracy limitations
+
+- **False positives are possible.** DevTime may name or claim a concept that is not
+  really there. The file-local evidence gating reduces this, but cannot eliminate it.
+- **False negatives are possible.** DevTime may miss a real concept whose evidence it
+  cannot parse (e.g. an unsupported framework or an unusual code style).
+- Confidence scores and Understanding Debt are **relative heuristics**, calibrated on
+  fixtures, not absolute measurements.
+
+## 3. Framework coverage limitations
+
+- DevTime is currently strongest on repositories that resemble its fixtures:
+  **TypeScript / JavaScript (Express, named routers, Next.js App Router)** and
+  **Python (FastAPI-style routes, Celery-style workers)**.
+- Frameworks **not** yet parsed include NestJS, Django, Flask, Rails, Spring, Go
+  HTTP frameworks, and many others. On these, detection degrades to weak,
+  dependency-level evidence (and DevTime should say so via uncertainty).
+
+## 4. Risk review limitations
+
+- `dtc risk --diff` is **advisory**. It is not a gate and must not block PRs.
+- It reviews a git diff against local memory using heuristics; it does not prove a
+  change is broken, and it can both miss real risks and surface ones that turn out to
+  be fine.
+- Risk findings are keyed to known patterns (e.g. retry/idempotency/duplicate-delivery
+  on billing webhooks). Coverage is narrow by design — *one precise warning beats ten
+  vague ones*.
+
+## 5. Privacy and security boundaries
+
+- DevTime runs locally: **no network access and no code execution during a scan.**
+- Ignored directories are pruned before traversal; ignored files and secrets are
+  excluded from evidence by design.
+- These are engineering boundaries enforced by code and tests, **not** a formal
+  security guarantee or audit. Review `dtc doctor --privacy` output for your repo.
+
+## 6. AI and MCP limitations
+
+- **No AI provider is wired.** DevTime never calls a model. AI narration is an
+  intentional future option, not part of V0.
+- **MCP transport is not wired.** The tool surface, schemas, and read-only permission
+  model exist in code, but there is no live server you can connect an agent to yet.
+
+## 7. Performance limitations
+
+- Scans prune ignored directories before traversal, which makes them fast on typical
+  repos (sub-second on the demo; ~0.5s on a 355-file real repo). Very large
+  repositories have not been extensively profiled.
+- Detection is single-pass and in-process; there is no incremental/cached scan yet.
+
+## 8. What is intentionally not built yet
+
+To keep V0 trustworthy rather than large, the following are deliberately **out of
+scope** for now:
+
+- git-history signals (freshness, ownership, lineage from commits)
+- wired MCP transport / write-enabled MCP tools
+- an AI provider integration
+- a UI
+- cloud, team sync, and enterprise policy layers
+- billing, auth, and multi-user features
+
+---
+
+*Trust before novelty. DevTime aims to be embarrassingly clear about both its promise
+and its limits.*

--- a/PROOF.md
+++ b/PROOF.md
@@ -1,140 +1,117 @@
 # DevTime — PROOF
 
-Evidence that DevTime V0 does what it claims, on real repositories — and an honest
-list of where it is still weak. Built and validated locally; AI off, cloud off,
-telemetry off, no code execution, no network.
+Evidence that DevTime V0 does what it claims, on a demo repo and on real
+repositories — plus an honest account of where it is still weak. Everything here is
+local: AI off, cloud off, telemetry off, no code execution, no network.
 
-## 1. Current V0 status
+## 1. Current version
 
-A local-first Engineering Intelligence CLI (`dtc`) that scans a repository, detects
-concepts, links them to evidence, generates governed claims with visible
-uncertainty, scores Understanding Debt, reviews diffs against memory, and produces
-Context Packs for humans and AI agents. SQLite memory in `.devtime/`.
-
+- Version `0.1.0`. Tags: `v0.0.1-proof`, `v0.0.2-reality`, and this `v0.0.3-public-candidate`.
 - Tests: **33 passing** (`pytest`) — unit, integration, and 16 fixtures.
-- Trust laws enforced as executable gates: no claim without evidence; usage is not
-  decision; uncertainty is output; ignored secrets never become evidence.
 
-### v0.0.2 Reality Hardening
+## 2. What works
 
-Two highest-confidence limitations from Reality Validation, fixed (no new features):
+CLI: `dtc init`, `dtc scan`, `dtc concepts`, `dtc explain`, `dtc evidence`,
+`dtc context`, `dtc risk --diff`, `dtc decision add`, `dtc debt`, `dtc status`,
+`dtc doctor --privacy`, `dtc export`, `dtc reset`.
 
-- **File-local Billing Webhooks gate.** Billing Webhooks now requires webhook and
-  billing evidence to be local to each other (same file / provider signature
-  handler), not merely present somewhere in the repo. Result on real repos: API
-  Graveyard's generic webhook-delivery system is **no longer** mislabelled Billing
-  Webhooks (its only billing association was an e2e spec path), while Snapilio's
-  PayPal webhook and the demo's Stripe webhook are still correctly detected.
-- **Walker prunes ignored directories before traversal.** node_modules, .git,
-  build output, .next/.sst, .devtime, etc. are skipped instead of walked-then-
-  filtered. API Graveyard scan time dropped from **~27.3s to ~0.48s** (≈56×), with
-  identical privacy behaviour (secrets under ignored paths are never visited).
-
-## 2. Commands that work
-
-```
-dtc init                         # create local memory
-dtc scan                         # detect concepts/evidence/claims (no code exec, no network)
-dtc concepts                     # list detected concepts with confidence + debt
-dtc explain <concept>            # claims + evidence + uncertainty + Understanding Debt
-dtc evidence <concept>           # raw evidence list with strength
-dtc context <concept> --mode risk# governed Context Pack for agents
-dtc risk --diff --base <ref>     # memory-aware review of a diff
-dtc decision add --title .. --body ..   # record rationale (closes Understanding Debt)
-dtc doctor --privacy             # privacy/boundary checks
-dtc export --format json|markdown
-dtc status / dtc reset
-```
+Trust laws enforced as executable gates: *no claim without evidence*, *usage is not
+decision*, *uncertainty is output*, and *ignored secrets never become evidence*.
 
 ## 3. Demo repo proof (`examples/demo-saas`)
 
-`dtc scan` detects Authentication, Billing Webhooks, Background Jobs, Data Export,
-Admin Permissions. Billing Webhooks correctly reports **"No decision was found"**
-and scores lower than Authentication (which has an ADR). `dtc risk --diff` on a
-retry-behavior change flags: *"Retry behavior changed without duplicate-delivery
-test changes"* (high). `dtc decision add` drops Billing Webhooks debt 56 → 72 and
-clears the uncertainty.
+`dtc scan` detects Authentication, Billing Webhooks, Background Jobs, Data Export, and
+Admin Permissions in `38 signals` across `15 files` in ~0.1s.
 
-## 4. Real-repo validation results
+- **Authentication scores higher because an ADR exists** (`docs/decisions/0001-use-jwt.md`):
+  its "why" is documented.
+- **Billing Webhooks scores lower because no decision exists**: strong behavior
+  evidence (route + Stripe signature verification + test) but Understanding Debt
+  `56/100` with explicit uncertainty "No decision was found explaining key choices".
 
-Validated against three real repositories (see `reports/reality-validation/`):
+## 4. Real repo validation proof
+
+Validated against three real repositories (reports in `reports/reality-validation/`):
 API Graveyard (FastAPI + TS), Snapilio (Next.js/SST), SaaSVoice (Next.js/SST).
 
-| Repo | Files | Signals | Key failure found |
-|------|-------|---------|-------------------|
-| API Graveyard | 355 | 1468 | "Billing Webhooks" false positive on a generic webhook system; Context Pack fabricated billing warnings; migration file used as Background Jobs evidence; e2e specs polluting evidence |
-| Snapilio | 186 | 649 | Next.js App Router routes invisible → every concept degraded to weak dependency evidence; `//` path bug |
-| SaaSVoice | 125 | 508 | NextAuth + all API routes missed; auth reported with no route evidence |
+| Repo | Files | Signals | Headline finding |
+|------|-------|---------|------------------|
+| API Graveyard | 355 | ~1.4k | False "Billing Webhooks" on a generic webhook system; migration mis-used as Background Jobs evidence |
+| Snapilio | 186 | 649 | Next.js App Router routes invisible → everything degraded to weak evidence |
+| SaaSVoice | 125 | 508 | NextAuth + all API routes missed |
 
-The single highest-leverage finding (two of three repos): **DevTime could not see the
-Next.js App Router**, the most common TS API stack.
+## 5. Before / after examples
 
-## 5. Before / after
+**Snapilio — Authentication:** before `confidence: medium` (dependency/doc only);
+after **`confidence: high`** with real `app/api/.../route.ts` route evidence.
 
-**Snapilio — Authentication**
-- Before: `confidence: medium`, evidence `dependency, doc, middleware`; claim was
-  only "has related dependencies present".
-- After: `confidence: high`, evidence now includes `route`; claim "Authentication
-  has active route handling" anchored on real `app/api/.../route.ts` handlers.
+**API Graveyard — Billing Webhooks:** before, a generic webhook delivery system was
+**mislabelled** Billing Webhooks; after the file-local evidence gate, it is **no
+longer detected** (its only billing association was an e2e spec path). Real billing
+webhooks (Snapilio PayPal, demo Stripe) are still correctly detected.
 
-**Snapilio — Billing Webhooks**
-- Before: weak dependency-only, no behavior.
-- After: `route` evidence + "has active route handling", anchored on the real
-  `app/api/paypal/webhook/route.ts`.
+**Demo — the decision loop:** `dtc explain "Billing Webhooks"` → Understanding Debt
+`56/100` with uncertainty. After `dtc decision add`, the uncertainty clears and debt
+improves to **`72/100`**.
 
-**API Graveyard — Background Jobs**
-- Before: evidence included `backend/alembic/versions/..._add_jobs.py` (a DB migration).
-- After: migrations excluded; no migration files in evidence.
+**Demo — risk review:** with retry behavior changed and no duplicate-delivery test
+touched, `dtc risk --diff` flags **high severity**: "Retry behavior changed without
+duplicate-delivery test changes."
 
-**API Graveyard — Context Pack**
-- Before: "Do Not Change: Signature verification behavior / Subscription state
-  transition mapping" — fabricated, no billing evidence in repo.
-- After: warnings derived from actual evidence ("Token issuing and verification
-  behavior", "Authorization / protected-route behavior", "Request handling for …").
+## 6. Fixture learning loop
 
-## 6. Fixtures added (10 new, from real failures)
+Every real failure became a fixture so it cannot silently regress:
 
-| Fixture | Locks in |
-|---------|----------|
-| `nextjs/nextjs-data-export-route` | App Router `route.ts` GET → Data Export route |
-| `nextjs/nextauth-authentication` | `api/auth/[...nextauth]/route.ts` → Authentication route |
-| `nextjs/paypal-webhook-is-billing` | PayPal webhook route → Billing Webhooks (real billing) |
-| `nextjs/nextjs-file-upload-route` | upload route → File Uploads |
-| `nextjs/nextjs-admin-route` | admin route → Admin Permissions |
-| `webhooks/generic-webhook-not-billing` | generic webhook must NOT be "Billing Webhooks" |
-| `jobs/migration-not-background-job` | migration file must NOT be Background Jobs evidence |
-| `evidence/e2e-spec-weak` | e2e UI spec must not define a concept alone |
-| `evidence/dependency-only-weak` | dependency-only concept stays weak + uncertain |
-| `express/express-named-router` | `authRouter.post(...)` detected (named routers) |
+- **Next.js App Router was initially missed**, then fixed and locked in by fixtures
+  (`nextjs-data-export-route`, `nextauth-authentication`, `paypal-webhook-is-billing`,
+  `nextjs-file-upload-route`, `nextjs-admin-route`).
+- **False Billing Webhooks detection was fixed by file-local evidence gating**, locked
+  in by `generic-webhook-not-billing`, `stripe-dep-alone-not-billing`,
+  `generic-webhook-plus-unrelated-billing-dep`, and the positive
+  `billing-webhook-local-stripe`.
+- Migration exclusion, e2e down-weighting, weak-only concepts, and named Express
+  routers each have fixtures too.
 
-Backed by scanner/claim fixes: Next.js extractor (`scanner/extractors/nextjs.py`),
-billing-evidence gate + weak-only gate (`intelligence/concepts.py`), evidence-derived
-Context Pack warnings (`intelligence/context_pack.py`), migration exclusion and e2e
-down-weighting (`scanner/signals.py`, `scanner/extractors/tests.py`), path
-normalization (`scanner/file_walker.py`).
+Fixtures grew the suite from 13 → **33 tests**.
 
-## 7. Known limitations (honest)
+## 7. Performance hardening
 
-- **Detection is pattern/regex-based.** Express, FastAPI, and Next.js App Router are
-  covered; other frameworks (NestJS, Django, Flask, Rails, Go) are not yet parsed.
-- **Billing proximity is file-level, not function-level.** Fixed to file-local in
-  v0.0.2 (repo-wide deps and generic webhooks no longer infer Billing Webhooks). A
-  single kitchen-sink file that references both webhooks and billing in unrelated
-  code could still co-locate tokens; function/route-level proximity is a future step.
-- **No git-history signals.** Freshness is a fixed placeholder; ownership is always
-  unconfirmed; lineage is not yet implemented.
-- **MCP transport not wired.** Tool logic exists; the server only describes the
-  read-only contract.
-- **AI provider disabled.** No narration provider is shipped.
-- Validation covered 3 real repos + the demo. Two more (a random open-source TS repo
-  and a standalone FastAPI repo) are planned on dedicated branches.
+The scanner now prunes ignored directories before traversal (`os.walk` +
+`PRUNE_DIRS`). **API Graveyard scan time improved from ~27.3s to ~0.48s (≈56×)**, with
+identical privacy behavior (secrets under ignored paths are never visited).
 
-## 8. Next recommended milestone
+## 8. Trust laws covered by tests
 
-Billing-gate file-locality and walker pruning are done (v0.0.2). Next: V0 Public
-Readiness — README trust model, clean-install instructions, CI green from a clean
-clone, a short demo. Then expand validation to 2 more open-source repos and grow the
-fixture suite. Only after that: `dtc doctor`, `dtc claim show <id>`,
-`dtc export --markdown` polish.
+- *No claim without evidence* — `tests/unit/test_claims.py`.
+- *Usage is not decision* — `tests/unit/test_claims.py`.
+- *Uncertainty is output* — scoring/claims tests assert missing-decision uncertainty.
+- *Ignored secrets never become evidence* — `tests/fixtures/test_privacy_fixtures.py`,
+  `tests/unit/test_walker_prune.py`.
+- *Risk review fires on the right change* — `tests/integration/test_risk_review.py`.
 
-> The milestone reached: **DevTime learned 10 real repo patterns and will not forget them.**
+## 9. What DevTime still does not do
+
+Heuristic scanner (not a compiler); limited framework coverage (strongest on
+TS/Next.js/Express/FastAPI); no git-history signals; MCP transport unwired; no AI
+provider; risk review advisory only; local-first with no cloud/team/UI. Full list in
+**[LIMITATIONS.md](LIMITATIONS.md)**.
+
+## 10. Next validation targets
+
+A standalone open-source FastAPI repo and a random open-source TypeScript repo, plus
+larger-repo performance profiling. Each new wrong output should become a fixture.
+
+---
+
+## Clean-install verification
+
+A fresh `git clone` was installed and exercised end to end:
+
+| Field | Result |
+|-------|--------|
+| OS | Windows 11 (Git Bash) |
+| Python | 3.11.9 |
+| Install command | `pip install -e ".[dev]"` |
+| Test result | **33 passed** |
+| Demo result | `dtc init` / `dtc scan` / `dtc concepts` / `dtc explain "Billing Webhooks"` all produced expected output from a clean clone |
+| Issue found & fixed | `dtc risk --diff` produced no findings when the scan root is a subdirectory of the git repo (path mismatch). Fixed with `git diff --relative`; the demo risk step now works. |

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,122 @@
+# Quickstart
+
+Get DevTime running and see the proof in a few minutes.
+
+## 1. Requirements
+
+- **Python ≥ 3.11** (developed and verified on 3.11.9)
+- **git**
+- A terminal. Works on Windows, macOS, and Linux.
+
+## 2. Clone
+
+```bash
+git clone https://github.com/Shakargy/devtime.git
+cd devtime
+```
+
+## 3. Install
+
+```bash
+python -m venv .venv
+source .venv/bin/activate          # Windows (PowerShell): .venv\Scripts\Activate.ps1
+                                   # Windows (Git Bash):   source .venv/Scripts/activate
+pip install -e ".[dev]"
+```
+
+This installs the `dtc` command into the virtual environment.
+
+## 4. Run tests
+
+```bash
+pytest
+```
+
+Expected: **33 passed**.
+
+## 5. Run the demo
+
+DevTime scans the **current directory**, so run the demo from inside the sample app:
+
+```bash
+cd examples/demo-saas
+dtc init
+dtc scan
+dtc concepts
+dtc explain "Authentication"
+dtc explain "Billing Webhooks"
+```
+
+To see risk review, see **[DEMO_SCRIPT.md](DEMO_SCRIPT.md)** (it shows how to create
+a safe demo diff and revert it).
+
+## 6. Expected output
+
+`dtc scan`:
+
+```
+Scan complete. 15 files, 38 signals, 5 concepts in 0.1s.
+```
+
+`dtc concepts` (order may vary):
+
+```
+1. Billing Webhooks   confidence: high    debt: medium
+2. Authentication     confidence: high    debt: medium
+3. Background Jobs    confidence: medium  debt: high
+4. Data Export        confidence: medium  debt: high
+5. Admin Permissions  confidence: medium  debt: high
+```
+
+`dtc explain "Billing Webhooks"` shows supported claims with evidence, an
+**Uncertainty** section ("No decision was found explaining key choices…"), and an
+**Understanding Debt** score of `56 / 100`.
+
+`dtc explain "Authentication"` scores higher, because the demo includes a decision
+record (`docs/decisions/0001-use-jwt.md`).
+
+## 7. Troubleshooting
+
+- **`dtc: command not found`** — your virtual environment is not active. Re-run the
+  activate command from step 3, or call the module directly: `python -m devtime.cli ...`.
+- **`DevTime is not initialized`** — run `dtc init` in the directory you want to scan.
+- **`No concept found matching '...'`** — run `dtc concepts` to see the exact names
+  (they are case-insensitive but must otherwise match).
+- **`risk --diff` shows no findings** — risk review needs a git diff in the current
+  directory. See DEMO_SCRIPT.md for the prepared demo change.
+
+## 8. Reset local memory
+
+DevTime's memory lives in `.devtime/` and is safe to delete. Your source code is
+never modified.
+
+```bash
+dtc reset            # deletes .devtime/ after confirmation
+# or simply:
+rm -rf .devtime
+```
+
+## Clean-install verification (maintainers)
+
+A fresh-clone check was run on the current candidate:
+
+- **OS:** Windows 11 (Git Bash)
+- **Python:** 3.11.9
+- **Install:** `pip install -e ".[dev]"`
+- **Tests:** `33 passed`
+- **Demo:** `dtc init` / `dtc scan` / `dtc concepts` / `dtc explain "Billing Webhooks"`
+  all produced the expected output from a clean `git clone`.
+
+To repeat it:
+
+```bash
+cd /tmp
+git clone https://github.com/Shakargy/devtime.git devtime-clean-test
+cd devtime-clean-test
+python -m venv .venv
+source .venv/Scripts/activate       # or .venv/bin/activate
+pip install -e ".[dev]"
+pytest
+cd examples/demo-saas
+dtc init && dtc scan && dtc concepts && dtc explain "Billing Webhooks"
+```

--- a/README.md
+++ b/README.md
@@ -1,33 +1,196 @@
 # DevTime
 
-DevTime builds evidence-backed repository memory.
+**Local-first Engineering Intelligence for software repositories.**
 
-It scans your repository locally, detects meaningful concepts, links claims to evidence,
-surfaces missing decisions, and prepares Context Packs for humans and AI agents.
+DevTime helps a repository explain itself from evidence. It scans code, tests,
+configs, routes, and decisions to identify the concepts inside a codebase, show the
+evidence behind them, surface uncertainty, and warn about risky changes.
 
-## Quickstart
+It does not execute your code. It does not send your code anywhere. It does not
+require AI. It does not pretend to know things without evidence.
 
-```
-dtc init
-dtc scan
-dtc concepts
-dtc explain Authentication
-dtc context "Billing Webhooks" --mode risk
-dtc risk --diff
-```
-
-## Trust model
-
-- Local-first by default.
-- AI optional.
-- Cloud disabled by default.
-- No source upload required.
-- Telemetry off or explicit.
-
-## Core law
-
-No claim without evidence.
+> No cloud. No telemetry. No code execution. No AI required.
 
 ---
 
-*Git remembers code. DevTime remembers understanding.*
+## Why this exists
+
+Git remembers *code*. It does not remember *understanding* — why a behavior exists,
+what evidence supports it, or what nobody has decided yet. As AI tools generate code
+faster than teams can review it, that missing understanding becomes the bottleneck.
+
+DevTime builds **evidence-backed repository memory**: a local layer that says what a
+repository can prove, and — just as importantly — what it cannot prove yet.
+
+## What DevTime does
+
+- **Detects concepts** — stable units of meaning like Authentication, Billing
+  Webhooks, Background Jobs — from routes, tests, configs, dependencies, and docs.
+- **Explains from evidence** — every claim links to the files/signals behind it.
+- **Surfaces uncertainty** — when evidence is missing (e.g. no decision record), it
+  says so instead of guessing.
+- **Scores Understanding Debt** — a product signal for how well a concept can be
+  explained, with the causes shown.
+- **Warns about risky changes** — `dtc risk --diff` reviews a git diff against local
+  memory and flags advisory findings.
+- **Records decisions** — `dtc decision add` stores rationale locally, which reduces
+  uncertainty and improves understanding.
+
+## What DevTime does not do
+
+- It does not execute your code.
+- It does not send code or data over the network.
+- It does not require or call an AI model.
+- It does not guarantee correctness or safe changes.
+- It does not replace code review or architecture decisions.
+- It is **not** a documentation generator, a static analyzer, an observability tool,
+  a productivity tracker, or an AI coding agent.
+
+See **[LIMITATIONS.md](LIMITATIONS.md)** for the full, honest list.
+
+## Trust model
+
+- DevTime stores local repository memory in `.devtime/` (a local SQLite database).
+- **No network access** during a scan.
+- **No code execution** during a scan.
+- Ignored directories are pruned *before* scanning; ignored files and secrets must
+  never become evidence or claims.
+- Every claim must link to evidence — *no claim without evidence*.
+- Weak evidence produces **uncertainty**, not confidence.
+- *Usage is not decision*: that a dependency is used does not mean someone decided
+  why.
+- Risk review is **advisory** by default — it does not block PRs.
+
+## Quick demo
+
+DevTime scans the **current directory**, so the demo runs from inside the demo app.
+
+```bash
+cd examples/demo-saas
+dtc init
+dtc scan
+dtc concepts
+dtc explain "Billing Webhooks"
+# ...make a change, then:
+dtc risk --diff
+dtc decision add --concept billing_webhooks \
+  --title "Webhook retry and idempotency strategy" \
+  --body "Retry subscription updates up to 3x; dedupe by Stripe event id."
+dtc explain "Billing Webhooks"
+```
+
+The narrative:
+
+- **Before a decision:** Billing Webhooks has strong evidence (route, signature
+  verification, test) *and* uncertainty — no decision explains its retry or
+  duplicate-delivery behavior. Understanding Debt is `56/100`.
+- **Risk review:** changing retry behavior without updating duplicate-delivery tests
+  is flagged **high severity**.
+- **After adding a decision:** the missing reasoning is now in repository memory, the
+  uncertainty clears, and Understanding Debt improves to `72/100`.
+
+A full, copy-pasteable walkthrough is in **[DEMO_SCRIPT.md](DEMO_SCRIPT.md)**.
+
+## Installation
+
+Requires **Python ≥ 3.11** and git.
+
+```bash
+git clone https://github.com/Shakargy/devtime.git
+cd devtime
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+pip install -e ".[dev]"
+pytest                              # 33 tests should pass
+```
+
+This installs the `dtc` command. See **[QUICKSTART.md](QUICKSTART.md)** for a
+step-by-step first run and troubleshooting.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `dtc init` | Create local `.devtime` memory. |
+| `dtc scan` | Scan the current repository and extract evidence-backed signals. |
+| `dtc concepts` | List detected concepts with confidence and Understanding Debt. |
+| `dtc explain <concept>` | Explain a concept: claims, evidence, confidence, uncertainty, Understanding Debt. |
+| `dtc context <concept>` | Create a governed Context Pack for agents or humans. |
+| `dtc risk --diff` | Review a git diff for risky changes using local evidence (advisory). |
+| `dtc decision add` | Add a local decision record that can reduce uncertainty. |
+
+(Also available: `dtc evidence`, `dtc debt`, `dtc status`, `dtc doctor --privacy`,
+`dtc export`, `dtc reset`.)
+
+## Example output
+
+```
+$ dtc explain "Billing Webhooks"
+Concept: Billing Webhooks
+
+Supported claims:
+  - Billing Webhooks is present in this repository.
+    type: concept  confidence: 0.86  evidence: src/billing/stripe-webhook.ts, tests/stripe-signature.test.ts
+  - Billing Webhooks has active route handling.
+    type: behavior  confidence: 0.82  evidence: src/billing/stripe-webhook.ts
+  - Billing Webhooks verifies webhook signatures.
+    type: behavior  confidence: 0.85  evidence: src/billing/stripe-webhook.ts
+
+Uncertainty:
+  - No decision was found explaining key choices for Billing Webhooks.
+
+Understanding Debt: 56 / 100 (medium)
+causes:
+  - missing decision evidence
+  - no confirmed owner
+```
+
+## Proof
+
+DevTime runs on `examples/demo-saas` and on real repositories. During Reality
+Validation it detected — and then learned from — real failures (Next.js App Router
+blindness, a false Billing Webhooks detection on a generic webhook system, a DB
+migration mis-counted as Background Jobs evidence, and more). Each failure became a
+fixture so it cannot silently regress.
+
+- Tests grew from 13 → **33 passing**.
+- Scan time on a 355-file real repo dropped from ~27.3s to ~0.48s after ignored-
+  directory pruning.
+
+Full evidence, before/after examples, and the validation reports are in
+**[PROOF.md](PROOF.md)** and `reports/reality-validation/`.
+
+## Privacy and safety
+
+- Runs entirely locally; nothing leaves your machine during a scan.
+- No code execution and no network calls during scanning.
+- Secrets and ignored files are excluded from evidence by design (`dtc doctor
+  --privacy` reports the boundaries).
+- `dtc reset` deletes local memory; your source code is never modified.
+
+## Known limitations
+
+DevTime is a **heuristic scanner**, not a full compiler or semantic analyzer. It is
+currently strongest on TypeScript / Next.js / Express / FastAPI-style repositories
+that resemble its fixtures. False positives and false negatives are possible.
+Understanding Debt is a product signal, not an objective universal truth.
+
+Read the full list — including framework coverage, risk-review scope, and what is
+intentionally not built yet — in **[LIMITATIONS.md](LIMITATIONS.md)**.
+
+## Roadmap
+
+This is an early, local-first V0 focused on being trustworthy before being large.
+Not yet built (intentionally): git-history signals, wired MCP transport, an AI
+provider, a UI, and any cloud/team/enterprise features. See LIMITATIONS.md.
+
+## Contributing
+
+The most valuable contribution is a **fixture**: a small repository pattern plus the
+expected concepts, allowed claims, forbidden claims, and required uncertainty. If
+DevTime gets something wrong on your code, that wrong output can become a fixture so
+it never regresses. See `fixtures/` for the format and `tests/` for how they run.
+
+## License
+
+No license has been chosen yet. **TODO: choose a license before public release.**

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,84 @@
+# Release Checklist
+
+Gate for taking DevTime from private to public. Current target tag:
+`v0.0.3-public-candidate`. **The repository stays private until a human approves the
+public release gate.**
+
+## 1. Code health
+
+- [x] No local DB committed (`.devtime/`, `*.sqlite` ignored and absent from tree)
+- [x] No `.devtime/` committed
+- [x] No secrets committed (privacy fixture uses an ignored `secrets.env` with fake values)
+- [x] No generated caches committed (`__pycache__`, `*.egg-info`, `.pytest_cache` ignored)
+- [x] No AI authorship traces (project policy: none in code, commits, or PR bodies)
+- [x] Clean `git status` on the release branch
+
+## 2. Tests
+
+- [x] `pytest` passes (33 passed)
+- [x] Fixture runner passes (16 fixtures)
+- [x] Trust-law tests pass (no claim without evidence; usage is not decision)
+- [x] Privacy fixtures pass (ignored secrets never become evidence)
+- [x] Risk fixtures pass (retry-without-test flagged)
+
+## 3. CI
+
+- [x] Green from a clean clone (`.github/workflows/ci.yml`)
+- [x] Advisory GitHub Action exits 0 (`.github/workflows/devtime-risk-review.yml`)
+- [x] No blocking PR behavior yet (risk review is advisory)
+
+## 4. Privacy
+
+- [x] No network during scan
+- [x] No code execution during scan
+- [x] Ignored directories pruned before traversal
+- [x] Ignored secrets never become evidence (covered by tests)
+
+## 5. Documentation
+
+- [x] README explains the trust model and links to LIMITATIONS.md
+- [x] QUICKSTART works from a clean clone (verified)
+- [x] PROOF.md has real before/after examples
+- [x] LIMITATIONS.md is visible and linked from README
+- [x] DEMO_SCRIPT.md tested (commands run, risk step verified)
+
+## 6. Demo
+
+- [x] Demo commands verified end to end
+- [x] Safe demo diff documented with revert step
+- [ ] 2–3 minute demo video recorded *(pending — human)*
+
+## 7. Packaging
+
+- [x] `pyproject.toml` is correct (`requires-python = ">=3.11"`, `dtc` entry point)
+- [x] Install command verified: `pip install -e ".[dev]"`
+- [ ] (Optional later) publish to PyPI — not required for private reviewers
+
+## 8. GitHub readiness
+
+- [x] README.md, QUICKSTART.md, PROOF.md, LIMITATIONS.md, DEMO_SCRIPT.md, RELEASE_CHECKLIST.md present
+- [x] `.gitignore`, `.gitattributes`, CI workflows present
+- [ ] **LICENSE chosen** *(pending — see TODO in README; required before public)*
+- [ ] Repository description / topics set on GitHub *(human)*
+
+## 9. Public release gate (all must be true)
+
+- [ ] A stranger can install and run the demo in under 10 minutes
+- [x] Known limitations are visible (LIMITATIONS.md, linked from README)
+- [ ] Demo video recorded
+- [ ] First 5–10 private reviewers have tested it
+- [ ] No major confusion reported about the README
+- [ ] LICENSE chosen
+- [ ] **Human approves flipping the repo to public**
+
+## 10. Post-release feedback loop
+
+- [ ] Issue template for "DevTime got this wrong" → convert to a fixture
+- [ ] Triage false positives / false negatives into fixtures
+- [ ] Track which frameworks reviewers tried (coverage gaps → next fixtures)
+- [ ] Re-run Reality Validation on new community repos
+
+---
+
+**Status:** ready for **private reviewers**. Not yet ready for **public** — blockers:
+LICENSE selection, a recorded demo video, and reviewer feedback.

--- a/src/devtime/cli.py
+++ b/src/devtime/cli.py
@@ -164,8 +164,11 @@ def risk(
         raise typer.Exit(code=2)
 
     try:
+        # --relative emits paths relative to the current directory, so diff paths
+        # match scan-root-relative evidence even when the scan root is a subdirectory
+        # of the git repository (e.g. running the demo from examples/demo-saas).
         diff_text = subprocess.run(
-            ["git", "diff", base],
+            ["git", "diff", "--relative", base],
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
## v0.0.3 public readiness

Packaging, documentation, and proof for V0 public readiness. No new product features.

### What changed
- **README.md** rewritten as a trust-first, public-facing README (positioning, trust model, comparison of what DevTime is / is not, command table, real example output, links to LIMITATIONS).
- **QUICKSTART.md** added — verified install + first-run from a clean clone, with troubleshooting and reset.
- **PROOF.md** polished to a 10-section structure with real before/after examples and a clean-install record.
- **LIMITATIONS.md** added — honest, visible, linked from the README (accuracy, framework coverage, risk-review scope, privacy boundaries, AI/MCP, performance, intentionally-not-built).
- **DEMO_SCRIPT.md** added — a 2–3 min evidence-first walkthrough with the exact safe risk diff and its revert step.
- **RELEASE_CHECKLIST.md** and **CLEAN_INSTALL_CHECK.md** added.
- **cli.py:** `dtc risk --diff` now runs `git diff --relative` so diff paths match scan-root-relative evidence when the scan root is a subdirectory of the git repo. This is a demo-breakage fix surfaced by the clean-install test (without it the documented demo risk step produced no findings). Not a new feature.

### Why it changed
A clean `git clone` → install → demo pass on the candidate revealed two doc-blocking facts: (1) `dtc scan` scans the current directory (so docs use `cd examples/demo-saas` rather than a path argument), and (2) the risk step produced no findings from a nested demo dir due to a path mismatch. Both are now correct and documented.

### Which Reality Validation finding caused it
None new — this phase packages the already-validated V0. The risk path fix is a clean-install regression caught while verifying the documented demo.

### Fixtures added or updated
None. Documentation/packaging phase only.

### Test count
**33 passing** (unchanged); the `--relative` risk fix is covered by the existing risk integration test (which uses an inline diff).

### Known limitations still remaining
Heuristic scanner; limited framework coverage; no git-history signals; MCP transport unwired; no AI provider; risk review advisory; local-first only. See LIMITATIONS.md. LICENSE is still TODO (flagged in README and the checklist).

### Scope confirmation
No UI, cloud, auth, billing, team-sync, enterprise, AI-provider, write-enabled MCP, git-history signals, or new scanner families were added. The only code change is the `git diff --relative` demo fix.
