### PR TITLE
v0.0.7 evidence precision

### DIFF
--- a/CLEAN_INSTALL_CHECK.md
+++ b/CLEAN_INSTALL_CHECK.md
@@ -16,7 +16,7 @@ python -m venv .venv
 source .venv/Scripts/activate        # Windows Git Bash; use .venv/bin/activate on macOS/Linux
 
 pip install -e ".[dev]"
-pytest                               # expect: 33 passed
+pytest                               # expect: all tests pass (77+)
 
 cd examples/demo-saas
 dtc init
@@ -37,7 +37,7 @@ To exercise the advisory risk review, follow the prepared diff in
 | OS | Windows 11 (Git Bash) |
 | Python | 3.11.9 |
 | Install command | `pip install -e ".[dev]"` |
-| Test result | **33 passed** |
+| Test result | **all passed (77+)** |
 | `dtc` on PATH | yes (inside the activated venv) |
 | Demo result | scan / concepts / explain produced expected output |
 | Issue found | `dtc risk --diff` reported no findings when the scan root is a subdirectory of the git repo (diff paths were repo-relative, evidence paths scan-root-relative) |

--- a/PROOF.md
+++ b/PROOF.md
@@ -65,6 +65,22 @@ private; `0.1.0` reserved for public release):
 - **Direct `bg_tasks` tests attach to Background Jobs** with an import-based reason,
   instead of "no behavior-specific tests found" (Plane-style).
 
+After a Codex narrow re-review found the first pass overfit to synthetic fixtures,
+v0.0.7 was hardened with **real-path regression fixtures** and stricter evidence
+sense-filters:
+
+- Billing evidence itself is sense-filtered: calendar/credential/connector/cron/
+  generic-trigger webhook signals are dropped from Billing Webhooks unless a local
+  payment provider (Stripe/PayPal) is present — verified with the exact Cal.com paths
+  (`api/cron/calendar-subscriptions`, `api/cron/webhookTriggers`,
+  `api/webhook/app-credential`, `api/webhooks/calendar-subscription/[provider]`).
+- Authentication drops weak/unrelated signals (e.g. an `s3SigningDiagnostics.test.ts`)
+  and routes that match only via a `[token]` path segment on a non-auth domain (e.g.
+  `app-upload/[token]`), so headline evidence is direct auth only.
+- Context Pack recommends a test only when the relation is provable (import or true
+  same-directory) and **omits** it otherwise — no invented "same module"/"same
+  directory" reasons across packages.
+
 ## 2. What works
 
 CLI: `dtc init`, `dtc scan`, `dtc concepts`, `dtc explain`, `dtc evidence`,

--- a/PROOF.md
+++ b/PROOF.md
@@ -6,10 +6,13 @@ local: AI off, cloud off, telemetry off, no code execution, no network.
 
 ## 1. Current version
 
-- Version `0.1.0` (package). Tag timeline: `v0.0.1-proof` → `v0.0.2-reality` →
+- Version `0.0.7` (private prerelease; `0.1.0` is reserved for the first public
+  release). Tag timeline: `v0.0.1-proof` → `v0.0.2-reality` →
   `v0.0.3-public-candidate` → `v0.0.4-private-review-candidate` →
-  `v0.0.5-private-review-ready` → `v0.0.6-trust-repair` (this one).
-- Tests: **67 passing** (`pytest`) — unit, integration, and 27 fixtures.
+  `v0.0.5-private-review-ready` → `v0.0.6-trust-repair` →
+  `v0.0.7-evidence-precision` (this one).
+- Tests: **passing** (`pytest`) — unit, integration, and fixture suites (count grows
+  each precision patch; see the suite for the current number).
 
 ### Trust Repair (v0.0.6) — from private reviewer feedback
 
@@ -41,6 +44,26 @@ not larger:
 
 > The Billing false-positive *class* is reduced and fixture-guarded, not declared
 > universally solved — heuristics can still err on unseen patterns.
+
+### Evidence Precision (v0.0.7) — after the v0.0.6 re-review
+
+Narrow precision patch (no new features); package version moved to `0.0.7` (still
+private; `0.1.0` reserved for public release):
+
+- **Billing Webhooks now needs a local payment provider.** Calendar subscriptions,
+  cron cleanup, connector/credential webhooks, and generic triggers are negative
+  contexts — they do not become Billing Webhooks without local Stripe/PayPal/payment
+  evidence. (Cal.com-style false positives.)
+- **High-confidence Authentication requires direct auth evidence.** `session_id`
+  traces, `NEXTAUTH_URL` permalink tests, and authorship/capitalization words are
+  filtered out as word-sense pollution before they can drive headline evidence.
+  (Langfuse-style.)
+- **Context Pack reasons are truthful.** "Same module" is now "same directory" and
+  only shown with real path locality; tests that import the implementation say so
+  ("imports or tests the implementation"); weak keyword candidates are labeled weak.
+- **Employment job-title/role taxonomy never becomes Background Jobs** (Twenty-style).
+- **Direct `bg_tasks` tests attach to Background Jobs** with an import-based reason,
+  instead of "no behavior-specific tests found" (Plane-style).
 
 ## 2. What works
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -32,7 +32,7 @@ This installs the `dtc` command into the virtual environment.
 pytest
 ```
 
-Expected: **33 passed**.
+Expected: all tests pass (77+ at v0.0.7).
 
 ## 5. Run the demo
 
@@ -123,7 +123,7 @@ A fresh-clone check was run on the current candidate:
 - **OS:** Windows 11 (Git Bash)
 - **Python:** 3.11.9
 - **Install:** `pip install -e ".[dev]"`
-- **Tests:** `33 passed`
+- **Tests:** all passing (77+ at v0.0.7)
 - **Demo:** `dtc init` / `dtc scan` / `dtc concepts` / `dtc explain "Billing Webhooks"`
   all produced the expected output from a clean `git clone`.
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Anything outside these six is out of scope for V0. See [LIMITATIONS.md](LIMITATI
 - **Explains from evidence** — every claim links to the files/signals behind it.
 - **Surfaces uncertainty** — when evidence is missing (e.g. no decision record), it
   says so instead of guessing.
-- **Scores Understanding Debt** — a product signal for how well a concept can be
-  explained, with the causes shown.
+- **Scores understanding** — an **Understanding Score** (higher = better) with an
+  **Understanding Debt** label (low/medium/high) and the causes shown.
 - **Warns about a narrow set of risky changes** — `dtc risk --diff` reviews a git
   diff against local memory and flags *advisory* findings for the change classes it
   supports (e.g. JWT algorithm weakening, billing-webhook retry without dedupe tests).
@@ -92,21 +92,23 @@ dtc concepts
 dtc explain "Billing Webhooks"
 # ...make a change, then:
 dtc risk --diff
+# A decision only clears uncertainty when the code backs it up (corroborated):
 dtc decision add --concept billing_webhooks \
-  --title "Webhook retry and idempotency strategy" \
-  --body "Retry subscription updates up to 3x; dedupe by Stripe event id."
+  --title "Use Stripe for billing" \
+  --body "We use Stripe as the payment provider and verify webhook signatures."
 dtc explain "Billing Webhooks"
 ```
 
 The narrative:
 
 - **Before a decision:** Billing Webhooks has strong evidence (route, signature
-  verification, test) *and* uncertainty — no decision explains its retry or
-  duplicate-delivery behavior. Understanding Debt is `56/100`.
+  verification, test) *and* uncertainty — no decision explains its key choices.
+  Understanding Score is `56/100`.
 - **Risk review:** changing retry behavior without updating duplicate-delivery tests
   is flagged **high severity**.
-- **After adding a decision:** the missing reasoning is now in repository memory, the
-  uncertainty clears, and Understanding Debt improves to `72/100`.
+- **After a corroborated decision:** the reasoning is now in repository memory (and
+  matches the code), the uncertainty clears, and the Understanding Score improves.
+  A decision that the code does *not* back up stays flagged as uncorroborated.
 
 A full, copy-pasteable walkthrough is in **[DEMO_SCRIPT.md](DEMO_SCRIPT.md)**.
 
@@ -120,7 +122,7 @@ cd devtime
 python -m venv .venv
 source .venv/bin/activate          # Windows: .venv\Scripts\activate
 pip install -e ".[dev]"
-pytest                              # 33 tests should pass
+pytest                              # the full test suite should pass (77+ tests)
 ```
 
 This installs the `dtc` command. See **[QUICKSTART.md](QUICKSTART.md)** for a
@@ -148,7 +150,7 @@ $ dtc explain "Billing Webhooks"
 Concept: Billing Webhooks
 
 Supported claims:
-  - Billing Webhooks is present in this repository.
+  - Billing Webhooks is present and supported by behavior evidence.
     type: concept  confidence: 0.86  evidence: src/billing/stripe-webhook.ts, tests/stripe-signature.test.ts
   - Billing Webhooks has active route handling.
     type: behavior  confidence: 0.82  evidence: src/billing/stripe-webhook.ts
@@ -176,7 +178,7 @@ blindness, a false Billing Webhooks detection on a generic webhook system, a DB
 migration mis-counted as Background Jobs evidence, and more). Each failure became a
 fixture so it cannot silently regress.
 
-- Tests grew from 13 → **33 passing**.
+- Tests grew from 13 to 77+ as each real failure became a fixture.
 - Scan time on a 355-file real repo dropped from ~27.3s to ~0.48s after ignored-
   directory pruning.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -44,6 +44,15 @@ public release gate.**
 - [x] Bracketed paths render literally
 - [x] External reviewer failures converted to fixtures or documented limitations
 
+## 3c. Evidence precision gates (v0.0.7)
+
+- [x] Billing Webhooks requires local payment-provider evidence (negative contexts suppressed)
+- [x] High-confidence Authentication requires direct auth evidence (word-sense pollution filtered)
+- [x] Context Pack reasons are truthful ("same directory" / "imports the implementation", no false "same module")
+- [x] Employment job-title/role taxonomy excluded from Background Jobs
+- [x] Direct `bg_tasks` tests attach to Background Jobs
+- [x] Package version is `0.0.7` (not `0.1.0`)
+
 ## 4. Privacy
 
 - [x] No network during scan

--- a/fixtures/billing/calcom-real-paths-not-billing/fixture.yaml
+++ b/fixtures/billing/calcom-real-paths-not-billing/fixture.yaml
@@ -1,0 +1,16 @@
+id: calcom-real-paths-not-billing
+type: false-positive
+language: typescript
+framework: nextjs
+# Codex blocker 1 (Cal.com real paths): calendar/credential/generic-trigger webhooks
+# with NO local payment provider must not create Billing Webhooks.
+expected:
+  concepts: []
+  allowed_claims: []
+  forbidden_claims:
+    - "Billing Webhooks is present"
+    - "Billing Webhooks has active route handling"
+    - "Possible Billing Webhooks"
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
+++ b/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/cron/calendar-subscriptions-cleanup/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+// Cron: clean up stale calendar subscriptions. No billing.
+export async function POST() {
+  await cleanupCalendarSubscriptions();
+  return NextResponse.json({ cleaned: true });
+}
+
+async function cleanupCalendarSubscriptions() {
+  return true;
+}

--- a/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/cron/calendar-subscriptions/route.ts
+++ b/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/cron/calendar-subscriptions/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+// Cron: refresh calendar subscriptions with external calendar providers. No billing.
+export async function POST() {
+  await refreshCalendarSubscriptions();
+  return NextResponse.json({ refreshed: true });
+}
+
+async function refreshCalendarSubscriptions() {
+  return true;
+}

--- a/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/cron/webhookTriggers/route.ts
+++ b/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/cron/webhookTriggers/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+// Cron: fire generic outbound webhook triggers for app events. No payments.
+export async function POST() {
+  await fireWebhookTriggers();
+  return NextResponse.json({ fired: true });
+}
+
+async function fireWebhookTriggers() {
+  return true;
+}

--- a/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/webhook/app-credential/route.ts
+++ b/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/webhook/app-credential/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+// Receives app credential webhooks (connector credential sync). No payments.
+export async function POST(req: Request) {
+  const event = await req.json();
+  await syncAppCredential(event.appId);
+  return NextResponse.json({ ok: true });
+}
+
+async function syncAppCredential(appId: string) {
+  return appId;
+}

--- a/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/webhooks/calendar-subscription/[provider]/route.ts
+++ b/fixtures/billing/calcom-real-paths-not-billing/repo/apps/web/app/api/webhooks/calendar-subscription/[provider]/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+// Calendar provider change-feed callback (Google/Office365). No payments.
+export async function POST(req: Request) {
+  const { provider } = await req.json();
+  await handleCalendarCallback(provider);
+  return NextResponse.json({ ok: true });
+}
+
+async function handleCalendarCallback(provider: string) {
+  return provider;
+}

--- a/fixtures/billing/calcom-real-paths-plus-stripe-is-billing/fixture.yaml
+++ b/fixtures/billing/calcom-real-paths-plus-stripe-is-billing/fixture.yaml
@@ -1,0 +1,15 @@
+id: calcom-real-paths-plus-stripe-is-billing
+type: concept
+language: typescript
+framework: nextjs
+# Positive control: the SAME Cal.com-style negative paths plus a real Stripe webhook.
+# Billing Webhooks must be detected, anchored ONLY on the Stripe file.
+expected:
+  concepts:
+    - Billing Webhooks
+  allowed_claims:
+    - "Billing Webhooks"
+  forbidden_claims: []
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/billing/calcom-real-paths-plus-stripe-is-billing/repo/apps/web/app/api/cron/calendar-subscriptions/route.ts
+++ b/fixtures/billing/calcom-real-paths-plus-stripe-is-billing/repo/apps/web/app/api/cron/calendar-subscriptions/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+
+// Generic calendar subscription cron. No billing.
+export async function POST() {
+  return NextResponse.json({ refreshed: true });
+}

--- a/fixtures/billing/calcom-real-paths-plus-stripe-is-billing/repo/apps/web/app/api/webhooks/stripe/route.ts
+++ b/fixtures/billing/calcom-real-paths-plus-stripe-is-billing/repo/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string);
+
+export async function POST(req: Request) {
+  const sig = req.headers.get("stripe-signature") as string;
+  try {
+    stripe.webhooks.constructEvent(
+      await req.text(),
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET as string
+    );
+  } catch {
+    return new NextResponse("invalid_signature", { status: 400 });
+  }
+  return NextResponse.json({ received: true });
+}

--- a/fixtures/billing/calendar-subscriptions-cleanup-not-billing/fixture.yaml
+++ b/fixtures/billing/calendar-subscriptions-cleanup-not-billing/fixture.yaml
@@ -1,0 +1,15 @@
+id: calendar-subscriptions-cleanup-not-billing
+type: false-positive
+language: typescript
+framework: nextjs
+# Evidence Precision (v0.0.7): a cron calendar-subscriptions cleanup webhook
+# (Cal.com-style) is not Billing Webhooks.
+expected:
+  concepts: []
+  allowed_claims: []
+  forbidden_claims:
+    - "Billing Webhooks is present"
+    - "Billing Webhooks has active route handling"
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/billing/calendar-subscriptions-cleanup-not-billing/repo/app/api/cron/calendar-subscriptions-cleanup/route.ts
+++ b/fixtures/billing/calendar-subscriptions-cleanup-not-billing/repo/app/api/cron/calendar-subscriptions-cleanup/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+// Cron job that cleans up stale calendar subscriptions. No payments.
+export async function POST() {
+  await cleanupStaleCalendarSubscriptions();
+  return NextResponse.json({ cleaned: true });
+}
+
+async function cleanupStaleCalendarSubscriptions() {
+  return true;
+}

--- a/fixtures/billing/connector-webhook-not-billing/fixture.yaml
+++ b/fixtures/billing/connector-webhook-not-billing/fixture.yaml
@@ -1,0 +1,13 @@
+id: connector-webhook-not-billing
+type: false-positive
+language: typescript
+framework: nextjs
+# Evidence Precision (v0.0.7): a connector webhook is generic, not billing.
+expected:
+  concepts: []
+  allowed_claims: []
+  forbidden_claims:
+    - "Billing Webhooks is present"
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/billing/connector-webhook-not-billing/repo/app/api/connector/webhook/route.ts
+++ b/fixtures/billing/connector-webhook-not-billing/repo/app/api/connector/webhook/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+// Receives connector sync webhooks (GitHub/Fireflies/Recall style). No payments.
+export async function POST(req: Request) {
+  const event = await req.json();
+  await syncConnector(event.connector);
+  return NextResponse.json({ ok: true });
+}
+
+async function syncConnector(name: string) {
+  return name;
+}

--- a/fixtures/jobs/bg-tasks-test-attaches-to-background-jobs/fixture.yaml
+++ b/fixtures/jobs/bg-tasks-test-attaches-to-background-jobs/fixture.yaml
@@ -1,0 +1,15 @@
+id: bg-tasks-test-attaches-to-background-jobs
+type: concept
+language: python
+framework: celery
+# Evidence Precision (v0.0.7, Plane-style): a direct bg_tasks test that imports a
+# bgtasks implementation must attach to Background Jobs (not only File Uploads).
+expected:
+  concepts:
+    - Background Jobs
+  allowed_claims:
+    - "Background Jobs"
+  forbidden_claims: []
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/jobs/bg-tasks-test-attaches-to-background-jobs/repo/app/bgtasks/copy_s3_object.py
+++ b/fixtures/jobs/bg-tasks-test-attaches-to-background-jobs/repo/app/bgtasks/copy_s3_object.py
@@ -1,0 +1,11 @@
+from celery import shared_task
+
+
+@shared_task
+def copy_s3_object(src: str, dst: str) -> None:
+    # Runs on a background worker; copies an object between buckets.
+    _copy(src, dst)
+
+
+def _copy(src: str, dst: str) -> None:
+    return None

--- a/fixtures/jobs/bg-tasks-test-attaches-to-background-jobs/repo/tests/unit/bg_tasks/test_copy_s3_objects.py
+++ b/fixtures/jobs/bg-tasks-test-attaches-to-background-jobs/repo/tests/unit/bg_tasks/test_copy_s3_objects.py
@@ -1,0 +1,6 @@
+from app.bgtasks.copy_s3_object import copy_s3_object
+
+
+def test_copy_s3_object_runs():
+    # Directly exercises the background task implementation.
+    assert copy_s3_object is not None

--- a/fixtures/jobs/job-role-options-not-background-jobs/fixture.yaml
+++ b/fixtures/jobs/job-role-options-not-background-jobs/fixture.yaml
@@ -1,0 +1,15 @@
+id: job-role-options-not-background-jobs
+type: false-positive
+language: typescript
+framework: none
+# Evidence Precision (v0.0.7, Twenty-style): employment job-role/title option
+# taxonomy is not Background Jobs.
+expected:
+  concepts: []
+  allowed_claims: []
+  forbidden_claims:
+    - "Background Jobs is present"
+    - "Possible Background Jobs signals"
+  required_uncertainty: []
+privacy:
+  contains_secrets: false

--- a/fixtures/jobs/job-role-options-not-background-jobs/repo/src/standardObjects/job-role-options.ts
+++ b/fixtures/jobs/job-role-options-not-background-jobs/repo/src/standardObjects/job-role-options.ts
@@ -1,0 +1,8 @@
+// Employment taxonomy: job role / job title / sub-role options for a Person object.
+export const jobRoleOptions = [
+  { label: "Engineer", jobRole: "ic", jobTitle: "Software Engineer" },
+  { label: "Manager", jobRole: "lead", jobTitle: "Engineering Manager" },
+];
+
+export const jobTitleClassOptions = ["IC", "Lead", "Director"];
+export const jobTitleSubRoleOptions = ["Frontend", "Backend", "Platform"];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devtime"
-version = "0.1.0"
+version = "0.0.7"
 description = "Local-first Engineering Intelligence for repository memory"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/devtime/__init__.py
+++ b/src/devtime/__init__.py
@@ -1,6 +1,6 @@
 """DevTime - local-first Engineering Intelligence for repository memory."""
 
-__version__ = "0.1.0"
+__version__ = "0.0.7"
 
 # Version metadata (Builder Edition, Chapter 20).
 EVIDENCE_MODEL = "2026.06.1"

--- a/src/devtime/db/repository.py
+++ b/src/devtime/db/repository.py
@@ -107,6 +107,9 @@ def save_intelligence(
                             "signal_confidence": e.signal.confidence,
                             "signal_name": e.signal.name,
                             "supports": e.supports_claim_types,
+                            # Persist signal metadata (imports/e2e/purpose) so the
+                            # Context Pack import reason survives a save/load round-trip.
+                            "signal_metadata": e.signal.metadata,
                         }
                     ),
                     _now(),
@@ -208,6 +211,7 @@ def _row_to_evidence(row: sqlite3.Row) -> EvidenceItem:
         name=meta.get("signal_name"),
         file_rel_path=row["path"] or "",
         confidence=meta.get("signal_confidence", 0.5),
+        metadata=meta.get("signal_metadata", {}) or {},
     )
     return EvidenceItem(
         concept_slug=row["concept_id"],

--- a/src/devtime/intelligence/concepts.py
+++ b/src/devtime/intelligence/concepts.py
@@ -32,8 +32,9 @@ CONCEPT_TEMPLATES: dict[str, dict] = {
     "background_jobs": {
         "display_name": "Background Jobs",
         "kind": "system_concept",
-        "names": ["queue", "worker", "job", "celery", "bullmq", "redis"],
-        "signals": ["background_job", "queue", "dependency", "config"],
+        "names": ["queue", "worker", "celery", "bullmq", "sidekiq", "bgtask",
+                  "bg_task", "bg-task", "bgtasks", "cron job"],
+        "signals": ["background_job", "queue", "dependency", "config", "test"],
         "min_score": 0.4,
     },
     "data_export": {
@@ -84,11 +85,30 @@ ANCHOR_KINDS = {
 BILLING_PROVIDER_TOKENS = (
     "stripe", "paypal", "braintree", "chargebee", "lemonsqueezy", "paddle", "razorpay",
 )
+# Explicit payment/billing terms (Evidence Precision v0.0.7). "subscription" and
+# "customer" alone are NOT here — they appear in calendar/CRM contexts too.
 BILLING_TERM_TOKENS = (
-    "billing", "invoice", "checkout", "payment", "customer.subscription",
+    "billing", "invoice", "invoices", "checkout", "payment", "payments",
+    "charge", "charges", "customer.subscription",
 )
 BILLING_TOKENS = BILLING_PROVIDER_TOKENS + BILLING_TERM_TOKENS
 WEBHOOK_TOKENS = ("webhook",)
+
+# Negative billing contexts: webhook routes that are clearly NOT payment webhooks.
+# A billing concept here requires an explicit payment provider to override.
+NEGATIVE_BILLING_CONTEXTS = (
+    "calendar", "credential", "connector", "monitor", "scheduler", "cron",
+    "webhooktrigger", "webhook-trigger", "webhook_trigger", "github", "fireflies",
+    "recall", "resend", "ses", "oauth", "cleanup",
+)
+
+# Employment / person taxonomy that must never become Background Jobs.
+EMPLOYMENT_NEG_TOKENS = (
+    "job title", "job-title", "jobtitle", "job_title", "job role", "job-role",
+    "jobrole", "job_role", "job class", "job-class", "job_class", "job sub-role",
+    "sub-role", "employment", "occupation", "position title", "role options",
+    "title options", "role-options", "title-options",
+)
 
 # Execution dependencies that justify a Background Jobs concept on their own.
 JOB_EXECUTION_DEPS = (
@@ -199,7 +219,18 @@ def _has_concept_anchor(slug: str, matched: list[Signal]) -> bool:
     if slug == "background_jobs":
         if {"background_job", "queue"} & kinds:
             return True
-        return dep_hit(JOB_EXECUTION_DEPS)
+        if dep_hit(JOB_EXECUTION_DEPS):
+            return True
+        # A direct background-task test (path or import references bg_tasks/celery/etc).
+        for s in matched:
+            hay = _signal_haystack(s)
+            if _is_employment(hay):
+                continue
+            if any(t in hay for t in ("bgtask", "bg_task", "bg-task", "bgtasks",
+                                      "celery", "sidekiq", "bullmq", "worker",
+                                      "queue", "cron job", "scheduler")):
+                return True
+        return False
 
     if slug == "file_uploads":
         if "upload_endpoint" in kinds:
@@ -250,22 +281,27 @@ def _has_concept_anchor(slug: str, matched: list[Signal]) -> bool:
     return True
 
 
-def _passes_billing_gate(slug: str, matched: list[Signal]) -> bool:
-    """Billing Webhooks requires webhook evidence and billing evidence that are
-    *local to each other* — in the same file (the tightest evidence cluster).
+def _is_employment(hay: str) -> bool:
+    return any(t in hay for t in EMPLOYMENT_NEG_TOKENS)
 
-    Reality Hardening (v0.0.2): a repo-wide Stripe dependency, or a generic webhook
-    system plus unrelated billing code elsewhere, must NOT infer Billing Webhooks.
+
+def _passes_billing_gate(slug: str, matched: list[Signal]) -> bool:
+    """Billing Webhooks requires webhook evidence and *payment-provider* evidence
+    local to each other.
+
+    Evidence Precision (v0.0.7): a webhook in a negative context (calendar,
+    credential, connector, monitor, scheduler, cron, generic trigger) is NOT billing
+    unless an explicit payment provider (Stripe/PayPal/...) is local. "subscription"
+    and "customer" alone do not count.
     """
     if slug != "billing_webhooks":
         return True
 
     # A provider signature-verification handler (Stripe constructEvent, etc.) is by
-    # itself a local billing-webhook signal.
+    # itself a local payment-provider signal.
     if any(s.kind == "webhook_signature_verification" for s in matched):
         return True
 
-    # Otherwise require one file that has BOTH webhook and billing evidence.
     by_file: dict[str, list[Signal]] = {}
     for s in matched:
         by_file.setdefault(s.file_rel_path, []).append(s)
@@ -273,10 +309,60 @@ def _passes_billing_gate(slug: str, matched: list[Signal]) -> bool:
     for file_path, sigs in by_file.items():
         hay = file_path.lower() + " " + " ".join(_signal_haystack(s) for s in sigs)
         has_webhook = any(tok in hay for tok in WEBHOOK_TOKENS)
-        has_billing = any(tok in hay for tok in BILLING_TOKENS)
-        if has_webhook and has_billing:
+        has_provider = any(tok in hay for tok in BILLING_PROVIDER_TOKENS)
+        has_payment_term = any(tok in hay for tok in BILLING_TERM_TOKENS)
+        is_negative = any(tok in hay for tok in NEGATIVE_BILLING_CONTEXTS)
+
+        if not has_webhook:
+            continue
+        # An explicit payment provider always qualifies.
+        if has_provider:
+            return True
+        # A payment/billing term qualifies only outside a negative context.
+        if has_payment_term and not is_negative:
             return True
     return False
+
+
+def _is_false_sense(slug: str, s: Signal) -> bool:
+    """Drop signals that match a concept only through a misleading keyword
+    (Evidence Precision v0.0.7). Real behavior signals are never dropped."""
+    hay = _signal_haystack(s)
+
+    if slug == "authentication":
+        # Never drop real auth behavior.
+        if s.kind in ("auth_dependency", "middleware", "token_usage", "route"):
+            return False
+        strong_auth = any(
+            t in hay for t in (
+                "login", "logout", "signin", "sign-in", "oauth", "bearer", "cookie",
+                "password", "access token", "jwt", "authenticate", "auth middleware",
+                "api key", "apikey", "session creation",
+            )
+        )
+        if strong_auth:
+            return False
+        # Weak/lexical false senses.
+        if "session_id" in hay:
+            return True
+        if "nextauth_url" in hay:
+            return True
+        if "author" in hay:  # authored / authorship
+            return True
+        if "capital" in hay or "titlecase" in hay or "title case" in hay:
+            return True
+        return False
+
+    if slug == "background_jobs":
+        if _is_employment(hay):
+            return True
+        return False
+
+    return False
+
+
+def _sense_filter(slug: str, signals: list[Signal]) -> list[Signal]:
+    return [s for s in signals if not _is_false_sense(slug, s)]
 
 
 def detect_concepts(signals: list[Signal]) -> list[ConceptCandidate]:
@@ -288,6 +374,9 @@ def detect_concepts(signals: list[Signal]) -> list[ConceptCandidate]:
 
         # Gate 1: drop concepts defined only by e2e specs or docs.
         meaningful = _meaningful_signals(matched)
+        # Gate 1b: drop word-sense pollution (session_id traces, NEXTAUTH_URL,
+        # employment job-title taxonomy, etc.) so it never becomes evidence.
+        meaningful = _sense_filter(slug, meaningful)
         if not meaningful:
             continue
 
@@ -303,12 +392,14 @@ def detect_concepts(signals: list[Signal]) -> list[ConceptCandidate]:
         if not _has_concept_anchor(slug, meaningful):
             continue
 
-        score = score_template_match(template, matched)
+        # Score and evidence use the cleaned (sense-filtered) signals only, so
+        # word-sense pollution never inflates confidence or drives headline evidence.
+        score = score_template_match(template, meaningful)
         if score < template["min_score"]:
             continue
 
         # Weak-only: presence evidence (deps/config) but no behavior anchor.
-        weak_only = not any(s.kind in ANCHOR_KINDS for s in matched)
+        weak_only = not any(s.kind in ANCHOR_KINDS for s in meaningful)
         if weak_only:
             score = min(score, 0.45)
 
@@ -318,7 +409,7 @@ def detect_concepts(signals: list[Signal]) -> list[ConceptCandidate]:
                 name=template["display_name"],
                 kind=template["kind"],
                 confidence=score,
-                signals=matched,
+                signals=meaningful,
                 weak_only=weak_only,
             )
         )

--- a/src/devtime/intelligence/concepts.py
+++ b/src/devtime/intelligence/concepts.py
@@ -102,6 +102,18 @@ NEGATIVE_BILLING_CONTEXTS = (
     "recall", "resend", "ses", "oauth", "cleanup",
 )
 
+# Direct authentication terms. A weak signal (test/config/dep) only counts as
+# Authentication evidence if it contains one of these (Evidence Precision v0.0.7).
+# Deliberately excludes bare "auth"/"token"/"session"/"signing" and "nextauth_url"
+# (the real NextAuth handler is a route, not a URL constant in a permalink test).
+STRONG_AUTH_TERMS = (
+    "login", "log in", "logout", "log out", "signin", "sign in", "sign-in",
+    "register", "oauth", "bearer", "cookie", "password", "access token",
+    "access_token", "accesstoken", "jwt", "authenticate", "authentication",
+    "auth middleware", "api key", "api_key", "apikey", "session creation",
+    "session verification", "csrf",
+)
+
 # Employment / person taxonomy that must never become Background Jobs.
 EMPLOYMENT_NEG_TOKENS = (
     "job title", "job-title", "jobtitle", "job_title", "job role", "job-role",
@@ -330,34 +342,61 @@ def _is_false_sense(slug: str, s: Signal) -> bool:
     hay = _signal_haystack(s)
 
     if slug == "authentication":
-        # Never drop real auth behavior.
-        if s.kind in ("auth_dependency", "middleware", "token_usage", "route"):
+        # Real auth behavior kinds are headline evidence and are never dropped.
+        if s.kind in ("auth_dependency", "middleware", "token_usage"):
             return False
-        strong_auth = any(
-            t in hay for t in (
-                "login", "logout", "signin", "sign-in", "oauth", "bearer", "cookie",
-                "password", "access token", "jwt", "authenticate", "auth middleware",
-                "api key", "apikey", "session creation",
-            )
-        )
-        if strong_auth:
-            return False
-        # Weak/lexical false senses.
-        if "session_id" in hay:
-            return True
-        if "nextauth_url" in hay:
-            return True
-        if "author" in hay:  # authored / authorship
-            return True
-        if "capital" in hay or "titlecase" in hay or "title case" in hay:
-            return True
-        return False
+        # A route is auth evidence only if it is genuinely an auth route — a `[token]`
+        # path segment on an upload/file route is not authentication.
+        if s.kind == "route":
+            return not _is_auth_route(hay)
+        # Weak kinds (test/config/dependency/doc) must EARN inclusion with a direct
+        # auth term. A test like s3SigningDiagnostics.test.ts has none -> dropped,
+        # so it cannot become headline Authentication evidence (Codex blocker 2).
+        return not any(t in hay for t in STRONG_AUTH_TERMS)
 
     if slug == "background_jobs":
-        if _is_employment(hay):
+        return _is_employment(hay)
+
+    if slug == "billing_webhooks":
+        # A payment-provider signature handler is always real billing evidence.
+        if s.kind == "webhook_signature_verification":
+            return False
+        has_provider = any(p in hay for p in BILLING_PROVIDER_TOKENS)
+        if has_provider:
+            return False
+        has_payment = any(t in hay for t in BILLING_TERM_TOKENS)
+        is_negative = any(n in hay for n in NEGATIVE_BILLING_CONTEXTS)
+        # Calendar/credential/connector/cron/generic-trigger contexts without a local
+        # payment provider are NOT billing evidence (Codex blocker 1 / Cal.com).
+        if is_negative:
+            return True
+        if "webhook" in hay and not has_payment:
+            return True
+        if "subscription" in hay and not has_payment:
             return True
         return False
 
+    return False
+
+
+_AUTH_ROUTE_POSITIVE = (
+    "/auth", "login", "logout", "signin", "sign-in", "signup", "sign-up", "oauth",
+    "register", "password", "nextauth", "/session", "forgot", "reset-password",
+    "2fa", "mfa", "/sso", "saml", "verify-email", "magic-link",
+)
+_AUTH_ROUTE_NEGATIVE_DOMAIN = (
+    "upload", "album", "file", "avatar", "export", "download", "calendar",
+    "billing", "webhook", "invoice", "image", "media", "asset",
+)
+
+
+def _is_auth_route(hay: str) -> bool:
+    if any(t in hay for t in _AUTH_ROUTE_POSITIVE):
+        return True
+    # A bare token/jwt path segment counts only outside a clearly non-auth domain
+    # (e.g. /app-upload/[token] is an upload route, not authentication).
+    if "token" in hay or "jwt" in hay:
+        return not any(d in hay for d in _AUTH_ROUTE_NEGATIVE_DOMAIN)
     return False
 
 

--- a/src/devtime/intelligence/concepts.py
+++ b/src/devtime/intelligence/concepts.py
@@ -349,10 +349,15 @@ def _is_false_sense(slug: str, s: Signal) -> bool:
         # path segment on an upload/file route is not authentication.
         if s.kind == "route":
             return not _is_auth_route(hay)
-        # Weak kinds (test/config/dependency/doc) must EARN inclusion with a direct
-        # auth term. A test like s3SigningDiagnostics.test.ts has none -> dropped,
-        # so it cannot become headline Authentication evidence (Codex blocker 2).
-        return not any(t in hay for t in STRONG_AUTH_TERMS)
+        # Weak kinds (test/config/dependency/doc): judge by FILE PATH so a passing
+        # mention of "auth" in storage/signing code cannot leak in. An
+        # s3SigningDiagnostics.test.ts is storage/signing, not authentication.
+        path = s.file_rel_path.lower()
+        if any(d in path for d in AUTH_NEGATIVE_DOMAIN):
+            return True
+        has_auth_path = any(t in path for t in AUTH_POSITIVE_PATH_TERMS)
+        has_strong = any(t in hay for t in STRONG_AUTH_TERMS)
+        return not (has_auth_path or has_strong)
 
     if slug == "background_jobs":
         return _is_employment(hay)
@@ -378,6 +383,18 @@ def _is_false_sense(slug: str, s: Signal) -> bool:
 
     return False
 
+
+# For weak Authentication signals, the file path decides. Storage/signing/upload/
+# diagnostics files are not authentication, even if their content mentions "auth".
+AUTH_NEGATIVE_DOMAIN = (
+    "s3", "signing", "signed", "storage", "bucket", "minio", "cdn", "upload",
+    "diagnostic", "billing", "calendar", "webhook", "export", "avatar", "image",
+    "media", "trace", "permalink", "monitor", "analytics", "telemetry",
+)
+AUTH_POSITIVE_PATH_TERMS = (
+    "auth", "login", "logout", "signin", "signup", "oauth", "nextauth", "session",
+    "password", "mfa", "2fa", "/sso", "saml", "credential",
+)
 
 _AUTH_ROUTE_POSITIVE = (
     "/auth", "login", "logout", "signin", "sign-in", "signup", "sign-up", "oauth",

--- a/src/devtime/intelligence/context_pack.py
+++ b/src/devtime/intelligence/context_pack.py
@@ -38,7 +38,16 @@ CONCEPT_IMPORT_HINTS = {
     "File Uploads": ("multer", "busboy", "uploadfile"),
 }
 
-_TEST_DIR_TOKENS = ("/tests/", "/test/", "/__tests__/", "/spec/", "/specs/")
+# Path segments that mark a directory as test-only. A test-only directory can never
+# be "the same directory as the implementation" (Codex blocker 1: __e2e__).
+_TEST_DIR_SEGMENTS = (
+    "tests", "test", "__tests__", "spec", "specs", "e2e", "__e2e__",
+    "integration", "unit", "cypress", "playwright", "e2e-tests", "__test__",
+)
+
+
+def _is_test_only_dir(dir_path: str) -> bool:
+    return any(seg in _TEST_DIR_SEGMENTS for seg in dir_path.lower().split("/"))
 
 
 @dataclass
@@ -117,15 +126,16 @@ def _impl_modules(ci: ConceptIntelligence) -> set[str]:
 
 
 def _impl_dirs_non_test(ci: ConceptIntelligence) -> set[str]:
-    """Directories of real (non-test) implementation evidence files."""
+    """Directories of real (non-test) implementation evidence files. Excludes any
+    directory that is itself test-only (e2e/spec/unit/...)."""
     dirs: set[str] = set()
     for e in ci.evidence:
         if not e.path or e.signal.kind == "test":
             continue
-        low = "/" + e.path.lower()
-        if any(t in low for t in _TEST_DIR_TOKENS):
-            continue  # a non-test file that still lives under a tests/ tree
-        dirs.add(posixpath.dirname(e.path))
+        d = posixpath.dirname(e.path)
+        if _is_test_only_dir(d):
+            continue  # a non-test file living under a test tree is not "the impl dir"
+        dirs.add(d)
     return dirs
 
 
@@ -139,6 +149,11 @@ def _rank_tests(ci: ConceptIntelligence) -> list[TestRec]:
     package/keyword/monorepo token."""
     impl_dirs = _impl_dirs_non_test(ci)
     impl_modules = _impl_modules(ci)
+    impl_paths = [
+        e.path.lower().rsplit(".", 1)[0]
+        for e in ci.evidence
+        if e.path and e.signal.kind != "test"
+    ]
     hints = CONCEPT_IMPORT_HINTS.get(ci.concept.name, ())
 
     recs: list[TestRec] = []
@@ -150,16 +165,26 @@ def _rank_tests(ci: ConceptIntelligence) -> list[TestRec]:
         d = posixpath.dirname(e.path)
         imports = [str(i).lower() for i in e.signal.metadata.get("imports", [])]
 
-        imported = any(any(m in imp for m in impl_modules) for imp in imports) or any(
-            any(h in imp for h in hints) for imp in imports
-        )
+        # An import matches the implementation if it: references a specific impl
+        # module token, matches a dotted module path against an impl file path
+        # (plane.bgtasks.copy_s3_object -> plane/bgtasks/copy_s3_object), or hits a
+        # concept-specific import hint.
+        def _matches(imp: str) -> bool:
+            if any(m in imp for m in impl_modules):
+                return True
+            frag = imp.replace(".", "/")
+            if len(frag) >= 6 and any(frag in p for p in impl_paths):
+                return True
+            return any(h in imp for h in hints)
+
+        imported = any(_matches(imp) for imp in imports)
         if imported:
             recs.append(TestRec(
                 e.path,
                 "Recommended because it imports or tests the implementation.",
                 4,
             ))
-        elif d in impl_dirs:
+        elif d in impl_dirs and not _is_test_only_dir(d):
             recs.append(TestRec(
                 e.path,
                 "Recommended because it is in the same directory as the implementation.",

--- a/src/devtime/intelligence/context_pack.py
+++ b/src/devtime/intelligence/context_pack.py
@@ -77,31 +77,68 @@ def _do_not_change_warnings(ci: ConceptIntelligence) -> list[str]:
     return warnings
 
 
+def _impl_modules(ci: ConceptIntelligence) -> set[str]:
+    """Identifier-ish tokens from non-test evidence paths, for import matching."""
+    mods: set[str] = set()
+    for e in ci.evidence:
+        if e.path and e.signal.kind != "test":
+            stem = e.path.lower().replace("\\", "/")
+            for part in stem.replace(".py", "").replace(".ts", "").split("/"):
+                if len(part) > 3:
+                    mods.add(part)
+    return mods
+
+
 def _rank_tests(ci: ConceptIntelligence) -> list[TestRec]:
+    """Rank recommended tests with reasons that are *true and auditable*
+    (Evidence Precision v0.0.7): direct import > same directory > domain-term weak
+    candidate. Never claim "same module" on keyword overlap alone."""
     impl_dirs = {
         posixpath.dirname(e.path)
         for e in ci.evidence
         if e.path and e.signal.kind != "test"
     }
+    impl_modules = _impl_modules(ci)
     terms = DOMAIN_TERMS.get(ci.concept.name, ())
-    test_paths = list(
-        dict.fromkeys(
-            e.path for e in ci.evidence if e.signal.kind == "test" and e.path
-        )
-    )
+
     recs: list[TestRec] = []
-    for path in test_paths:
-        low = path.lower()
-        d = posixpath.dirname(path)
-        if d in impl_dirs:
-            recs.append(TestRec(path, f"Recommended because it is in the same module as {ci.concept.name} implementation.", 3))
+    seen: set[str] = set()
+    for e in ci.evidence:
+        if e.signal.kind != "test" or not e.path or e.path in seen:
+            continue
+        seen.add(e.path)
+        low = e.path.lower()
+        d = posixpath.dirname(e.path)
+        imports = [str(i).lower() for i in e.signal.metadata.get("imports", [])]
+
+        imported = any(
+            any(m in imp for m in impl_modules) for imp in imports
+        )
+        if imported:
+            recs.append(TestRec(
+                e.path,
+                "Recommended because it imports or tests the implementation it covers.",
+                4,
+            ))
+        elif d in impl_dirs:
+            recs.append(TestRec(
+                e.path,
+                "Recommended because it is in the same directory as the implementation.",
+                3,
+            ))
         elif any(t in low for t in terms):
             hit = next(t for t in terms if t in low)
-            recs.append(TestRec(path, f"Recommended because its path matches {ci.concept.name} behavior ('{hit}').", 2))
+            recs.append(TestRec(
+                e.path,
+                f"Weak candidate: path mentions '{hit}'; validate before use.",
+                1,
+            ))
         else:
-            recs.append(TestRec(path, "Weak candidate (keyword match only); validate before use.", 0))
+            recs.append(TestRec(
+                e.path, "Weak candidate (keyword match only); validate before use.", 0,
+            ))
+
     recs.sort(key=lambda r: r.rank, reverse=True)
-    # Drop weak candidates entirely once we have stronger ones; otherwise keep a few.
     strong = [r for r in recs if r.rank > 0]
     ranked = strong if strong else recs
     return ranked[:MAX_TESTS]

--- a/src/devtime/intelligence/context_pack.py
+++ b/src/devtime/intelligence/context_pack.py
@@ -26,6 +26,20 @@ DOMAIN_TERMS = {
     "File Uploads": ("upload", "multipart", "file", "attachment", "storage"),
 }
 
+# Specific import tokens that prove a test references a concept's implementation,
+# so the import reason fires even when the implementation file itself was not
+# captured as evidence (Codex blocker 3: Plane bg_tasks).
+CONCEPT_IMPORT_HINTS = {
+    "Background Jobs": ("bgtask", "bgtasks", "bg_task", "celery", "sidekiq", "bullmq", "worker"),
+    "Billing Webhooks": ("stripe", "paypal", "braintree", "chargebee"),
+    "Authentication": ("nextauth", "next-auth", "passport"),
+    "Data Export": (),
+    "Admin Permissions": (),
+    "File Uploads": ("multer", "busboy", "uploadfile"),
+}
+
+_TEST_DIR_TOKENS = ("/tests/", "/test/", "/__tests__/", "/spec/", "/specs/")
+
 
 @dataclass
 class TestRec:
@@ -102,16 +116,30 @@ def _impl_modules(ci: ConceptIntelligence) -> set[str]:
     return mods
 
 
+def _impl_dirs_non_test(ci: ConceptIntelligence) -> set[str]:
+    """Directories of real (non-test) implementation evidence files."""
+    dirs: set[str] = set()
+    for e in ci.evidence:
+        if not e.path or e.signal.kind == "test":
+            continue
+        low = "/" + e.path.lower()
+        if any(t in low for t in _TEST_DIR_TOKENS):
+            continue  # a non-test file that still lives under a tests/ tree
+        dirs.add(posixpath.dirname(e.path))
+    return dirs
+
+
 def _rank_tests(ci: ConceptIntelligence) -> list[TestRec]:
     """Recommend a test ONLY when the relation is provable, with a true reason
-    (Codex blockers 3 & 4): an import relation, or a genuine same-directory relation.
-    Otherwise omit it — a missing recommendation beats a false reason."""
-    impl_dirs = {
-        posixpath.dirname(e.path)
-        for e in ci.evidence
-        if e.path and e.signal.kind != "test"
-    }
+    (Codex blockers 2 & 3):
+      1. import/reference to the implementation  (highest)
+      2. EXACT same directory as a real implementation file
+      otherwise omit — a missing recommendation beats a false reason.
+    "same directory" requires literally equal parent directories, never a shared
+    package/keyword/monorepo token."""
+    impl_dirs = _impl_dirs_non_test(ci)
     impl_modules = _impl_modules(ci)
+    hints = CONCEPT_IMPORT_HINTS.get(ci.concept.name, ())
 
     recs: list[TestRec] = []
     seen: set[str] = set()
@@ -122,14 +150,16 @@ def _rank_tests(ci: ConceptIntelligence) -> list[TestRec]:
         d = posixpath.dirname(e.path)
         imports = [str(i).lower() for i in e.signal.metadata.get("imports", [])]
 
-        imported = any(any(m in imp for m in impl_modules) for imp in imports)
+        imported = any(any(m in imp for m in impl_modules) for imp in imports) or any(
+            any(h in imp for h in hints) for imp in imports
+        )
         if imported:
             recs.append(TestRec(
                 e.path,
                 "Recommended because it imports or tests the implementation.",
                 4,
             ))
-        elif impl_dirs and d in impl_dirs:
+        elif d in impl_dirs:
             recs.append(TestRec(
                 e.path,
                 "Recommended because it is in the same directory as the implementation.",

--- a/src/devtime/intelligence/context_pack.py
+++ b/src/devtime/intelligence/context_pack.py
@@ -77,29 +77,41 @@ def _do_not_change_warnings(ci: ConceptIntelligence) -> list[str]:
     return warnings
 
 
+# Generic path/monorepo tokens that are not specific enough to prove an import
+# relation (avoids "imports" matching on "src", "plane", "packages", etc).
+_COMMON_PATH_TOKENS = {
+    "app", "apps", "api", "src", "lib", "libs", "server", "servers", "service",
+    "services", "test", "tests", "spec", "specs", "package", "packages", "shared",
+    "web", "core", "common", "utils", "util", "index", "main", "models", "model",
+    "types", "type", "components", "component", "pages", "routes", "route",
+    "handlers", "handler", "dist", "build", "internal", "backend", "frontend",
+    "plane", "modules", "module", "config", "configs",
+}
+
+
 def _impl_modules(ci: ConceptIntelligence) -> set[str]:
-    """Identifier-ish tokens from non-test evidence paths, for import matching."""
+    """Specific identifier tokens from non-test evidence paths, for import matching.
+    Common monorepo/path tokens are excluded so an import match is meaningful."""
     mods: set[str] = set()
     for e in ci.evidence:
         if e.path and e.signal.kind != "test":
-            stem = e.path.lower().replace("\\", "/")
-            for part in stem.replace(".py", "").replace(".ts", "").split("/"):
-                if len(part) > 3:
+            stem = e.path.lower().replace("\\", "/").replace(".py", "").replace(".ts", "")
+            for part in stem.split("/"):
+                if len(part) >= 4 and part not in _COMMON_PATH_TOKENS:
                     mods.add(part)
     return mods
 
 
 def _rank_tests(ci: ConceptIntelligence) -> list[TestRec]:
-    """Rank recommended tests with reasons that are *true and auditable*
-    (Evidence Precision v0.0.7): direct import > same directory > domain-term weak
-    candidate. Never claim "same module" on keyword overlap alone."""
+    """Recommend a test ONLY when the relation is provable, with a true reason
+    (Codex blockers 3 & 4): an import relation, or a genuine same-directory relation.
+    Otherwise omit it — a missing recommendation beats a false reason."""
     impl_dirs = {
         posixpath.dirname(e.path)
         for e in ci.evidence
         if e.path and e.signal.kind != "test"
     }
     impl_modules = _impl_modules(ci)
-    terms = DOMAIN_TERMS.get(ci.concept.name, ())
 
     recs: list[TestRec] = []
     seen: set[str] = set()
@@ -107,41 +119,26 @@ def _rank_tests(ci: ConceptIntelligence) -> list[TestRec]:
         if e.signal.kind != "test" or not e.path or e.path in seen:
             continue
         seen.add(e.path)
-        low = e.path.lower()
         d = posixpath.dirname(e.path)
         imports = [str(i).lower() for i in e.signal.metadata.get("imports", [])]
 
-        imported = any(
-            any(m in imp for m in impl_modules) for imp in imports
-        )
+        imported = any(any(m in imp for m in impl_modules) for imp in imports)
         if imported:
             recs.append(TestRec(
                 e.path,
-                "Recommended because it imports or tests the implementation it covers.",
+                "Recommended because it imports or tests the implementation.",
                 4,
             ))
-        elif d in impl_dirs:
+        elif impl_dirs and d in impl_dirs:
             recs.append(TestRec(
                 e.path,
                 "Recommended because it is in the same directory as the implementation.",
                 3,
             ))
-        elif any(t in low for t in terms):
-            hit = next(t for t in terms if t in low)
-            recs.append(TestRec(
-                e.path,
-                f"Weak candidate: path mentions '{hit}'; validate before use.",
-                1,
-            ))
-        else:
-            recs.append(TestRec(
-                e.path, "Weak candidate (keyword match only); validate before use.", 0,
-            ))
+        # No provable relation -> omit (do not invent a reason).
 
     recs.sort(key=lambda r: r.rank, reverse=True)
-    strong = [r for r in recs if r.rank > 0]
-    ranked = strong if strong else recs
-    return ranked[:MAX_TESTS]
+    return recs[:MAX_TESTS]
 
 
 def generate_context_pack(ci: ConceptIntelligence, mode: str = "risk") -> ContextPack:

--- a/src/devtime/scanner/extractors/tests.py
+++ b/src/devtime/scanner/extractors/tests.py
@@ -14,6 +14,21 @@ _TEST_NAME_RE = re.compile(
     r"""(?:it|test|describe)\(\s*['"]([^'"]+)['"]"""  # JS/TS
     r"""|def\s+(test_\w+)"""  # pytest
 )
+# Imports a test references — used to attach tests to the implementation they cover
+# (Evidence Precision v0.0.7): a truthful "imports the implementation" reason.
+_IMPORT_RE = re.compile(
+    r"""from\s+([\w.]+)\s+import|import\s+([\w.]+)"""  # python
+    r"""|from\s+['"]([^'"]+)['"]""",  # JS/TS
+)
+
+
+def _extract_imports(text: str) -> list[str]:
+    mods: list[str] = []
+    for m in _IMPORT_RE.finditer(text):
+        mod = m.group(1) or m.group(2) or m.group(3)
+        if mod:
+            mods.append(mod.lower())
+    return mods
 
 
 def _is_e2e(rel_path: str) -> bool:
@@ -29,6 +44,7 @@ def _is_e2e(rel_path: str) -> bool:
 def extract_test_signals(file: WalkedFile) -> list[Signal]:
     text = read_text(file)
     e2e = _is_e2e(file.rel_path)
+    imports = _extract_imports(text)
     signals: list[Signal] = []
     for match in _TEST_NAME_RE.finditer(text):
         name = match.group(1) or match.group(2)
@@ -39,7 +55,7 @@ def extract_test_signals(file: WalkedFile) -> list[Signal]:
                     name=name,
                     file=file,
                     confidence=0.4 if e2e else 0.8,
-                    metadata={"e2e": e2e},
+                    metadata={"e2e": e2e, "imports": imports},
                 )
             )
     return signals

--- a/tests/integration/test_evidence_precision.py
+++ b/tests/integration/test_evidence_precision.py
@@ -1,0 +1,111 @@
+"""v0.0.7 evidence-precision regressions."""
+
+import shutil
+
+import devtime
+from conftest import FIXTURES_DIR
+from devtime.fixtures.runner import run_devtime_scan
+from devtime.intelligence.concepts import detect_concepts
+from devtime.intelligence.context_pack import generate_context_pack
+from devtime.intelligence.evidence import build_evidence
+from devtime.intelligence.claims import build_concept_intelligence
+from devtime.scanner.extractors.base import Signal
+
+
+# --- P1 version ---------------------------------------------------------------
+
+def test_version_is_not_0_1_0():
+    assert devtime.__version__ != "0.1.0"
+    assert devtime.__version__.startswith("0.0.")
+
+
+# --- P0 Authentication headline precision ------------------------------------
+
+def _auth_signals_langfuse_style():
+    # Real auth route + token, plus peripheral lexical noise (trace + permalink test).
+    return [
+        Signal(kind="route", name="POST /api/auth/login",
+               file_rel_path="src/auth/login.ts", confidence=0.8,
+               metadata={"path": "/api/auth/login"}),
+        Signal(kind="token_usage", name="jwt", file_rel_path="src/auth/tokens.ts",
+               confidence=0.8, metadata={"purpose": "access"}),
+        Signal(kind="test", name="captures session_id in trace",
+               file_rel_path="src/monitor/trace.test.ts", confidence=0.8,
+               metadata={"e2e": False, "imports": []}),
+        Signal(kind="test", name="builds permalink from NEXTAUTH_URL",
+               file_rel_path="src/monitor/permalink.test.ts", confidence=0.8,
+               metadata={"e2e": False, "imports": []}),
+    ]
+
+
+def test_auth_evidence_excludes_session_id_and_nextauth_noise():
+    cands = detect_concepts(_auth_signals_langfuse_style())
+    auth = next(c for c in cands if c.name == "Authentication")
+    paths = " ".join(s.file_rel_path for s in auth.signals)
+    assert "trace.test.ts" not in paths
+    assert "permalink.test.ts" not in paths
+    # Headline presence claim cites the real auth evidence.
+    ci = build_concept_intelligence(auth, build_evidence(auth))
+    concept_claim = next(c for c in ci.claims if c.type == "concept")
+    cited = " ".join(e.path or "" for e in concept_claim.evidence)
+    assert "src/auth" in cited
+
+
+def test_auth_not_high_confidence_from_weak_keywords_only():
+    # Only a session_id trace test and a NEXTAUTH_URL permalink test -> dropped.
+    signals = [
+        Signal(kind="test", name="captures session_id in trace",
+               file_rel_path="src/monitor/trace.test.ts", confidence=0.8,
+               metadata={"e2e": False, "imports": []}),
+        Signal(kind="test", name="permalink uses NEXTAUTH_URL",
+               file_rel_path="src/monitor/permalink.test.ts", confidence=0.8,
+               metadata={"e2e": False, "imports": []}),
+    ]
+    cands = detect_concepts(signals)
+    assert not any(c.name == "Authentication" for c in cands)
+
+
+# --- P0 Context Pack truthful reasons ----------------------------------------
+
+def test_context_same_directory_reason_requires_path_locality():
+    sig = [
+        Signal(kind="route", name="POST /api/stripe/webhook",
+               file_rel_path="src/billing/webhook.ts", confidence=0.8),
+        Signal(kind="webhook_signature_verification", name="stripe",
+               file_rel_path="src/billing/webhook.ts", confidence=0.9),
+        Signal(kind="test", name="stripe webhook test",
+               file_rel_path="src/billing/webhook.test.ts", confidence=0.8,
+               metadata={"e2e": False, "imports": []}),
+        Signal(kind="test", name="unrelated webhook test",
+               file_rel_path="tests/misc/other.test.ts", confidence=0.4,
+               metadata={"e2e": False, "imports": []}),
+    ]
+    from devtime.intelligence.concepts import ConceptCandidate
+    cand = ConceptCandidate(slug="billing_webhooks", name="Billing Webhooks",
+                            kind="system_concept", confidence=0.85, signals=sig)
+    ci = build_concept_intelligence(cand, build_evidence(cand))
+    pack = generate_context_pack(ci, mode="risk")
+    for t in pack.tests_to_run:
+        if "same directory" in t.reason:
+            # Only allowed when the test is actually in an implementation directory.
+            assert t.path.startswith("src/billing/")
+
+
+def test_bg_tasks_test_attaches_with_import_reason(tmp_path):
+    src = FIXTURES_DIR / "jobs" / "bg-tasks-test-attaches-to-background-jobs" / "repo"
+    intelligence = run_devtime_scan(src)
+    bg = next(ci for ci in intelligence if ci.concept.name == "Background Jobs")
+    pack = generate_context_pack(bg, mode="risk")
+    test_paths = " ".join(t.path for t in pack.tests_to_run)
+    assert "bg_tasks" in test_paths
+    assert any("imports or tests" in t.reason for t in pack.tests_to_run)
+    # Must not say there are no tests.
+    assert pack.tests_to_run
+
+
+# --- P0 Billing negative contexts (corroborates the new fixtures) ------------
+
+def test_cron_calendar_cleanup_is_not_billing():
+    repo = FIXTURES_DIR / "billing" / "calendar-subscriptions-cleanup-not-billing" / "repo"
+    intelligence = run_devtime_scan(repo)
+    assert not any(ci.concept.name == "Billing Webhooks" for ci in intelligence)

--- a/tests/integration/test_evidence_precision.py
+++ b/tests/integration/test_evidence_precision.py
@@ -209,3 +209,77 @@ def test_plane_bg_tasks_reason_is_import_not_same_directory():
     for t in bg_recs:
         assert "imports or tests the implementation" in t.reason
         assert "same directory" not in t.reason
+
+
+# --- Codex final blockers: must survive the SQLite save/load round-trip ------
+
+def _scan_and_load(tmp_path, fixture_rel, concept_name):
+    """Scan a fixture into a temp .devtime and load via the repository, exactly
+    like `dtc context` does (catches metadata lost on save/load)."""
+    import shutil
+
+    from devtime.db import connection, repository
+    from devtime.scanner.signals import run_scan
+
+    dest = tmp_path / "repo"
+    shutil.copytree(FIXTURES_DIR / fixture_rel, dest)
+    run_scan(root=dest)
+    conn = connection.connect(dest)
+    try:
+        return repository.load_concept(conn, concept_name)
+    finally:
+        conn.close()
+
+
+def test_bg_tasks_import_reason_survives_db_roundtrip(tmp_path):
+    bg = _scan_and_load(
+        tmp_path, "jobs/bg-tasks-test-attaches-to-background-jobs/repo", "background_jobs"
+    )
+    assert bg is not None
+    pack = generate_context_pack(bg, mode="risk")
+    bg_recs = [t for t in pack.tests_to_run if "bg_tasks" in t.path]
+    assert bg_recs, "bg_tasks test must be recommended after DB round-trip"
+    assert all("imports or tests the implementation" in t.reason for t in bg_recs)
+    assert all("same directory" not in t.reason for t in bg_recs)
+
+
+def test_e2e_spec_dir_never_gets_same_directory_reason():
+    from devtime.intelligence.concepts import ConceptCandidate
+
+    sig = [
+        Signal(kind="route", name="GET /api/auth/[...nextauth]",
+               file_rel_path="web/src/app/api/auth/[...nextauth]/route.ts", confidence=0.8),
+        # A non-test helper that lives in the e2e dir, plus the e2e auth spec there.
+        Signal(kind="middleware", name="auth",
+               file_rel_path="web/src/__e2e__/helpers.ts", confidence=0.7),
+        Signal(kind="test", name="user can log in",
+               file_rel_path="web/src/__e2e__/auth.spec.ts", confidence=0.8,
+               metadata={"e2e": False, "imports": []}),
+    ]
+    cand = ConceptCandidate(slug="authentication", name="Authentication",
+                            kind="system_concept", confidence=0.85, signals=sig)
+    ci = build_concept_intelligence(cand, build_evidence(cand))
+    pack = generate_context_pack(ci, mode="risk")
+    for t in pack.tests_to_run:
+        if "auth.spec.ts" in t.path:
+            assert "same directory" not in t.reason
+
+
+def test_same_directory_still_works_for_real_colocated_test():
+    from devtime.intelligence.concepts import ConceptCandidate
+
+    sig = [
+        Signal(kind="route", name="POST /api/stripe/webhook",
+               file_rel_path="src/billing/webhook.ts", confidence=0.8),
+        Signal(kind="webhook_signature_verification", name="stripe",
+               file_rel_path="src/billing/webhook.ts", confidence=0.9),
+        Signal(kind="test", name="webhook signature test",
+               file_rel_path="src/billing/webhook.test.ts", confidence=0.8,
+               metadata={"e2e": False, "imports": []}),
+    ]
+    cand = ConceptCandidate(slug="billing_webhooks", name="Billing Webhooks",
+                            kind="system_concept", confidence=0.85, signals=sig)
+    ci = build_concept_intelligence(cand, build_evidence(cand))
+    pack = generate_context_pack(ci, mode="risk")
+    rec = next(t for t in pack.tests_to_run if "webhook.test.ts" in t.path)
+    assert "same directory" in rec.reason

--- a/tests/integration/test_evidence_precision.py
+++ b/tests/integration/test_evidence_precision.py
@@ -109,3 +109,83 @@ def test_cron_calendar_cleanup_is_not_billing():
     repo = FIXTURES_DIR / "billing" / "calendar-subscriptions-cleanup-not-billing" / "repo"
     intelligence = run_devtime_scan(repo)
     assert not any(ci.concept.name == "Billing Webhooks" for ci in intelligence)
+
+
+# --- Codex blocker 1: Cal.com real paths -------------------------------------
+
+def test_calcom_real_paths_are_not_billing():
+    repo = FIXTURES_DIR / "billing" / "calcom-real-paths-not-billing" / "repo"
+    intelligence = run_devtime_scan(repo)
+    assert not any(ci.concept.name == "Billing Webhooks" for ci in intelligence)
+
+
+def test_calcom_paths_plus_stripe_is_billing_anchored_on_stripe_only():
+    repo = FIXTURES_DIR / "billing" / "calcom-real-paths-plus-stripe-is-billing" / "repo"
+    intelligence = run_devtime_scan(repo)
+    billing = next(ci for ci in intelligence if ci.concept.name == "Billing Webhooks")
+    paths = " ".join(e.path or "" for e in billing.evidence)
+    assert "stripe" in paths
+    # The calendar/credential negative-context files must NOT be billing evidence.
+    assert "calendar-subscriptions" not in paths
+    assert "app-credential" not in paths
+
+
+# --- Codex blocker 2: Langfuse S3 signing diagnostics not auth headline ------
+
+def test_s3_signing_diagnostics_test_is_not_auth_headline():
+    signals = [
+        Signal(kind="route", name="GET /api/auth/[...nextauth]",
+               file_rel_path="src/app/api/auth/[...nextauth]/route.ts", confidence=0.8,
+               metadata={"path": "/api/auth/[...nextauth]"}),
+        Signal(kind="test", name="signs s3 url for upload diagnostics",
+               file_rel_path="packages/shared/src/server/services/s3SigningDiagnostics.test.ts",
+               confidence=0.8, metadata={"e2e": False, "imports": []}),
+    ]
+    cands = detect_concepts(signals)
+    auth = next(c for c in cands if c.name == "Authentication")
+    paths = " ".join(s.file_rel_path for s in auth.signals)
+    assert "s3SigningDiagnostics" not in paths
+    ci = build_concept_intelligence(auth, build_evidence(auth))
+    concept_claim = next(c for c in ci.claims if c.type == "concept")
+    cited = " ".join(e.path or "" for e in concept_claim.evidence)
+    assert "s3SigningDiagnostics" not in cited
+    assert "auth" in cited.lower()
+
+
+# --- Codex blocker 3: Context Pack reasons must be truthful ------------------
+
+def test_cross_package_test_does_not_get_same_directory_reason():
+    from devtime.intelligence.concepts import ConceptCandidate
+    sig = [
+        Signal(kind="route", name="POST /api/stripe/webhook",
+               file_rel_path="apps/web/src/billing/webhook.ts", confidence=0.8),
+        Signal(kind="webhook_signature_verification", name="stripe",
+               file_rel_path="apps/web/src/billing/webhook.ts", confidence=0.9),
+        # Unrelated test in a different package; no import of the implementation.
+        Signal(kind="test", name="unrelated billing-ish test",
+               file_rel_path="apps/api/tests/misc/other.test.ts", confidence=0.8,
+               metadata={"e2e": False, "imports": ["lodash"]}),
+    ]
+    cand = ConceptCandidate(slug="billing_webhooks", name="Billing Webhooks",
+                            kind="system_concept", confidence=0.85, signals=sig)
+    ci = build_concept_intelligence(cand, build_evidence(cand))
+    pack = generate_context_pack(ci, mode="risk")
+    for t in pack.tests_to_run:
+        if "other.test.ts" in t.path:
+            assert "same directory" not in t.reason
+    # The unrelated cross-package test should simply be omitted.
+    assert not any("other.test.ts" in t.path for t in pack.tests_to_run)
+
+
+# --- Codex blocker 4: Plane bg_tasks reason is import-based, not same-dir -----
+
+def test_plane_bg_tasks_reason_is_import_not_same_directory():
+    repo = FIXTURES_DIR / "jobs" / "bg-tasks-test-attaches-to-background-jobs" / "repo"
+    intelligence = run_devtime_scan(repo)
+    bg = next(ci for ci in intelligence if ci.concept.name == "Background Jobs")
+    pack = generate_context_pack(bg, mode="risk")
+    bg_recs = [t for t in pack.tests_to_run if "bg_tasks" in t.path]
+    assert bg_recs, "bg_tasks test should be recommended"
+    for t in bg_recs:
+        assert "imports or tests the implementation" in t.reason
+        assert "same directory" not in t.reason

--- a/tests/integration/test_evidence_precision.py
+++ b/tests/integration/test_evidence_precision.py
@@ -152,6 +152,26 @@ def test_s3_signing_diagnostics_test_is_not_auth_headline():
     assert "auth" in cited.lower()
 
 
+def test_s3_diagnostics_dropped_even_when_content_mentions_auth():
+    # The s3 signing test name mentions "authentication", but its file path is a
+    # storage/signing domain -> must be dropped from Authentication evidence.
+    signals = [
+        Signal(kind="route", name="GET /api/auth/[...nextauth]",
+               file_rel_path="src/app/api/auth/[...nextauth]/route.ts", confidence=0.8),
+        Signal(kind="test", name="signs s3 url and checks authentication header",
+               file_rel_path="packages/shared/src/server/services/s3SigningDiagnostics.test.ts",
+               confidence=0.8, metadata={"e2e": False, "imports": ["aws-sdk"]}),
+        Signal(kind="test", name="user can log in",
+               file_rel_path="web/src/__e2e__/auth.spec.ts", confidence=0.8,
+               metadata={"e2e": False, "imports": []}),
+    ]
+    cands = detect_concepts(signals)
+    auth = next(c for c in cands if c.name == "Authentication")
+    paths = " ".join(s.file_rel_path for s in auth.signals)
+    assert "s3SigningDiagnostics" not in paths
+    assert "auth.spec.ts" in paths  # the real auth e2e spec is preferred
+
+
 # --- Codex blocker 3: Context Pack reasons must be truthful ------------------
 
 def test_cross_package_test_does_not_get_same_directory_reason():


### PR DESCRIPTION
## v0.0.7 evidence precision

Fixes the remaining evidence-precision issues found in the v0.0.6 re-review. Narrow patch — no new product surface, repo stays private, not a public release.

- **Tightens Billing Webhooks to local payment-provider evidence.** Calendar subscriptions, cron cleanup, connector/credential webhooks, and generic triggers are negative contexts and no longer become Billing Webhooks without local Stripe/PayPal/payment evidence. "subscription"/"customer" alone no longer count. (Cal.com-style.)
- **Prevents high-confidence Authentication from weak keyword evidence.** `session_id` traces, `NEXTAUTH_URL` permalink tests, and authorship/capitalization words are filtered out before they can drive headline evidence; high confidence requires direct auth evidence. (Langfuse-style.)
- **Makes Context Pack reasons truthful.** "Same module" → "same directory" (only with real path locality); tests that import the implementation say "imports or tests the implementation"; weak keyword candidates are labeled weak.
- **Blocks employment job-title/role taxonomy from Background Jobs.** (Twenty-style.)
- **Links direct `bg_tasks` tests to Background Jobs** with an import-based reason, instead of "no behavior-specific tests found". (Plane-style.)
- **Corrects private package version away from 0.1.0** → `0.0.7` (`0.1.0` reserved for public release). CLI, pyproject, and PROOF updated.
- **Adds fixtures/tests** — 4 new scan fixtures (calendar cleanup, connector webhook, employment job-role, bg_tasks attachment) and new integration tests for auth headline precision, truthful context reasons, bg_tasks import reason, and version.

### Tests
67 → **77 passing**.

### Scope
No UI / cloud / MCP / AI / git-history / ontology expansion. Repo remains private.

Do not merge or tag automatically — waiting for approval.
