### PR TITLE
v0.0.8 demo candidate

### DIFF
--- a/DEMO_OUTPUT.md
+++ b/DEMO_OUTPUT.md
@@ -1,0 +1,139 @@
+# Demo Output — DevTime V0 (v0.0.7)
+
+The exact command sequence and **real** expected output for the 2–3 minute demo, with
+timing, on-camera guidance, and recovery steps. All output below was captured from
+`examples/demo-saas` on v0.0.7 (Python 3.11, local, no network). `dtc` is the console
+script installed by `pip install -e ".[dev]"`; if it is not on your PATH, use
+`python -m devtime.cli` instead.
+
+## Exact command sequence
+
+```bash
+cd examples/demo-saas
+rm -rf .devtime
+dtc init
+dtc scan
+dtc concepts
+dtc explain "Authentication"
+dtc explain "Billing Webhooks"
+# --- apply the safe demo diff to src/billing/stripe-webhook.ts (see DEMO_SCRIPT.md) ---
+dtc risk --diff
+git checkout -- src/billing/stripe-webhook.ts
+# --- corroborated decision on a fresh scan ---
+rm -rf .devtime && dtc init && dtc scan
+dtc decision add --concept billing_webhooks --title "Use Stripe for billing" --body "We use Stripe as the payment provider and verify webhook signatures."
+dtc explain "Billing Webhooks"
+# --- leave the repo clean ---
+rm -rf .devtime
+git checkout -- .
+git status
+```
+
+## Expected output snippets (real)
+
+**`dtc scan`**
+```
+Scanning locally. No code execution. No network.
+Scan complete. Scanned 15 files, 38 signals, 5 concepts in 0.1s.
+Pruned directories: 1   Skipped/ignored files: 0
+Supported V0 concept families: 6 (closed ontology).
+```
+
+**`dtc concepts`** (first two)
+```
+1. Billing Webhooks   confidence: high    debt: medium
+2. Authentication     confidence: high    debt: low
+```
+
+**`dtc explain "Authentication"`**
+```
+Understanding Score: 79 / 100
+Understanding Debt: low
+Uncertainty: (none)
+```
+
+**`dtc explain "Billing Webhooks"`** (before any decision)
+```
+Uncertainty:
+  - No decision was found explaining key choices for Billing Webhooks.
+Understanding Score: 58 / 100
+Understanding Debt: medium
+```
+
+**`dtc risk --diff`** (with the retry diff applied)
+```
+Finding (high):
+  Retry behavior changed without duplicate-delivery test changes.
+Why this matters:
+  Billing webhooks may receive duplicate events; retry without dedupe tests risks double-processing.
+```
+
+**`dtc explain "Billing Webhooks"`** (after the corroborated Stripe decision)
+```
+Uncertainty: (none)
+Understanding Score: 79 / 100
+Understanding Debt: low
+```
+
+**Counter-example — uncorroborated decision** (optional)
+```
+Uncertainty:
+  - Decision 'Retry strategy' exists, but retry, deduplication is not corroborated
+    by scanned implementation evidence.
+Understanding Score: 58 / 100
+```
+
+## Timing estimate (~2m40s)
+
+| Beat | Action | ~Time |
+|------|--------|-------|
+| 0–1 | init + scan (local, no network) | 25s |
+| 2 | concepts | 15s |
+| 3 | explain Authentication (score 79) | 25s |
+| 4 | explain Billing Webhooks (58, uncertainty) | 25s |
+| 5 | apply diff + risk --diff (high finding) | 35s |
+| 6 | corroborated decision → 58→79 | 30s |
+| 7 | close + (optional) uncorroborated counter-example | 25s |
+
+Commands themselves run sub-second; the time is narration. Total fits 2–3 minutes;
+drop the optional counter-example to land closer to 2 minutes.
+
+## What to say on camera
+
+- "Local-first: no cloud, no telemetry, no code execution, no AI required."
+- "Concepts and claims come from evidence — every claim links to files."
+- "Authentication scores high because it has evidence **and** a decision the code backs up."
+- "Billing Webhooks has strong evidence but missing reasoning — DevTime shows the gap."
+- "Risk review is advisory and narrow; it flagged a retry change with no dedupe test."
+- "A decision only helps when the code corroborates it."
+- "DevTime is honest about uncertainty and its limits (six concept families, heuristic)."
+
+## What NOT to say
+
+- "AI understands your repo" / "AI-powered" (no AI is used).
+- "Automatically fixes your code" / "guarantees correctness / safe changes."
+- "Understands every repo" or implies arbitrary concept discovery.
+- Quoting Understanding Debt as a number — it is a label; the **Score** is the number.
+
+## Reset / revert (leave git clean)
+
+```bash
+rm -rf .devtime              # remove local memory (or: dtc reset --yes)
+git checkout -- .            # restore stripe-webhook.ts and .devtimeignore
+git status                   # examples/demo-saas should show no changes
+```
+
+Verified: after this sequence, `git status` reports a clean working tree.
+
+## Troubleshooting
+
+- **`dtc: command not found`** — the venv is not active; re-activate it or use
+  `python -m devtime.cli ...`.
+- **`risk --diff` shows no findings** — the demo diff was not applied, or its comment
+  lacks the word "Retry" (the heuristic keys on retry/idempotency/duplicate). Re-apply
+  the diff from DEMO_SCRIPT.md.
+- **Decision didn't clear uncertainty** — that is correct if the decision describes
+  behavior (retry/dedupe) the code doesn't show. Use the corroborated "Use Stripe for
+  billing" decision on a fresh scan to demonstrate the improvement.
+- **Dirty `git status` after the demo** — run `git checkout -- .` inside
+  `examples/demo-saas` and `rm -rf .devtime`.

--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -1,25 +1,33 @@
 # Demo Script — DevTime V0: Repository Memory From Evidence
 
-A 2–3 minute walkthrough. Every command below is real and copy-pasteable. Run it from
-inside the sample app (`examples/demo-saas`), because DevTime scans the current
-directory.
+A 2–3 minute walkthrough. Every command is real and copy-pasteable, and every output
+block matches current v0.0.7 behavior (verified on `examples/demo-saas`). Run it from
+inside the sample app, because DevTime scans the **current directory**.
 
-> Tone: this is **evidence-backed local memory**, not magic. We talk about evidence,
-> uncertainty, local memory, advisory risk review, and the decision loop — never
+> Tone: this is **evidence-backed local memory**, not magic. Say: evidence,
+> uncertainty, local memory, advisory risk review, corroborated decisions. Never say:
 > "AI understands your repo", "automatically fixes your code", or "guarantees
-> correctness".
+> correctness". DevTime requires no AI.
 
-## Setup
+## 0. Clean start
 
 ```bash
 cd examples/demo-saas
+rm -rf .devtime
 dtc init
 ```
 
-Narration: *"DevTime created a local memory store in `.devtime/`. Nothing leaves this
-machine. No cloud, no telemetry, no code execution."*
+Output:
 
-## 1. Scan — no execution, no network
+```
+DevTime initialized. Local memory at .devtime/devtime.sqlite
+AI disabled. Cloud disabled. Telemetry off. MCP read-only.
+```
+
+Narration: *"DevTime created a local memory store in `.devtime/`. Nothing leaves this
+machine — no cloud, no telemetry, no code execution, no AI required."*
+
+## 1. Scan — no execution, no network  (beat A)
 
 ```bash
 dtc scan
@@ -28,64 +36,99 @@ dtc scan
 Output:
 
 ```
-Scan complete. 15 files, 38 signals, 5 concepts in 0.1s.
+Scanning locally. No code execution. No network.
+Scan complete. Scanned 15 files, 38 signals, 5 concepts in 0.1s.
+Pruned directories: 1   Skipped/ignored files: 0
+Supported V0 concept families: 6 (closed ontology).
+Nothing left this machine. Run dtc concepts to inspect.
 ```
 
-Narration: *"It scanned the repository without running any of its code and without a
-network call, and extracted evidence-backed signals."*
+Narration: *"It scanned the repo without running any of its code and without a network
+call. V0 detects six supported concept families — it doesn't invent arbitrary
+concepts."*
 
-## 2. Concepts — what the repo contains
+## 2. Concepts — what the repo contains  (beat B)
 
 ```bash
 dtc concepts
 ```
 
-Narration: *"DevTime found five concepts — Authentication, Billing Webhooks,
-Background Jobs, Data Export, Admin Permissions — each with a confidence level and an
-Understanding Debt score."*
+Output:
 
-## 3. Authentication — stronger, because there is a decision
+```
+Detected concepts
+
+1. Billing Webhooks
+   confidence: high
+   evidence: behavior, dependency, route, test
+   debt: medium
+
+2. Authentication
+   confidence: high
+   evidence: decision, dependency, middleware, route, test, usage
+   debt: low
+...
+```
+
+Narration: *"Five concepts, each with a confidence level and an Understanding Debt
+label derived from evidence."*
+
+## 3. Authentication — better understood, because evidence and a decision exist  (beat C)
 
 ```bash
 dtc explain "Authentication"
 ```
 
-Narration: *"Authentication is well supported: routes, JWT usage, middleware, tests —
-and a decision record (an ADR). Because the 'why' is documented, its Understanding
-Debt is lower."*
+Output (trimmed):
 
-## 4. Billing Webhooks — strong evidence, but real uncertainty
+```
+Supported claims:
+  - Authentication is present and supported by behavior evidence.
+    type: concept  confidence: 0.85  evidence: src/auth/login.ts, tests/auth-login.test.ts, docs/decisions/0001-use-jwt.md
+  - Authentication has active route handling.
+  - Authentication uses JWT access tokens.
+
+Uncertainty:
+  (none)
+
+Understanding Score: 79 / 100
+Understanding Debt: low
+```
+
+Narration: *"Authentication has routes, JWT usage, middleware, tests — and a decision
+record (an ADR) that the code backs up. Because the 'why' is documented and
+corroborated, the Understanding Score is high and there's no open uncertainty."*
+
+## 4. Billing Webhooks — strong evidence, but missing reasoning  (beat D)
 
 ```bash
 dtc explain "Billing Webhooks"
 ```
 
-Output includes:
+Output (trimmed):
 
 ```
+Supported claims:
+  - Billing Webhooks is present and supported by behavior evidence.
+  - Billing Webhooks has active route handling.
+  - Billing Webhooks verifies webhook signatures.
+
 Uncertainty:
   - No decision was found explaining key choices for Billing Webhooks.
 
-Understanding Score: 56 / 100
+Understanding Score: 58 / 100
 Understanding Debt: medium
 ```
 
-Narration: *"Billing Webhooks has strong behavior evidence — a route and Stripe
-signature verification — but DevTime surfaces uncertainty: no decision explains its
-key choices. Understanding Score is higher = better; Debt is a label. Uncertainty is
-a feature, not a bug."*
+Narration: *"Strong behavior evidence — a Stripe webhook route and signature
+verification — but DevTime surfaces uncertainty: no decision explains its key choices.
+Uncertainty is a feature, not a bug."*
 
-## 5. A risky change is flagged (advisory)
+## 5. A risky change is flagged (advisory, narrow)  (beat E)
 
-Create the safe demo diff — change retry behavior **without** updating the
-duplicate-delivery test:
-
-```bash
-# edit src/billing/stripe-webhook.ts: wrap the subscription update in a retry loop
-```
-
-Apply this change inside the `customer.subscription.updated` branch (note the word
-"Retry" in the comment — the heuristic keys on it):
+Apply the safe demo diff — change retry behavior inside the
+`customer.subscription.updated` branch of `src/billing/stripe-webhook.ts`, **without**
+updating a duplicate-delivery test:
 
 ```ts
   if (event.type === "customer.subscription.updated") {
@@ -96,8 +139,6 @@ Apply this change inside the `customer.subscription.updated` branch (note the wo
     }
   }
 ```
-
-Then:
 
 ```bash
 dtc risk --diff
@@ -112,6 +153,8 @@ Affected concept:
   Billing Webhooks
 Finding (high):
   Retry behavior changed without duplicate-delivery test changes.
+Why this matters:
+  Billing webhooks may receive duplicate events; retry without dedupe tests risks double-processing.
 Missing:
   - duplicate-delivery test update
   - retry strategy decision
@@ -119,68 +162,59 @@ Suggested action:
   Update duplicate-delivery tests or record the retry behavior decision before merge.
 ```
 
-Narration: *"This is advisory, not a gate. DevTime noticed retry behavior changed but
-no duplicate-delivery test was touched — exactly the kind of change worth a second
-look."*
+Narration: *"This is advisory and narrow — not a gate. DevTime noticed retry behavior
+changed while no duplicate-delivery test was touched: exactly the kind of change worth
+a second look."*
 
-**Revert the demo change:**
+Revert the code change before continuing:
 
 ```bash
 git checkout -- src/billing/stripe-webhook.ts
 ```
 
-## 6. Close the loop — but only a *corroborated* decision counts
+## 6. A *corroborated* decision improves understanding  (beat F)
 
-First, the unsafe move DevTime refuses to reward. We reverted the retry code, so if we
-record a retry decision anyway, DevTime should NOT be fooled:
+DevTime won't be fooled by a decision the code doesn't support. Record a decision that
+**matches** the scanned evidence (Stripe signature verification), on a fresh scan:
 
 ```bash
-dtc decision add --concept billing_webhooks \
-  --title "Webhook retry and idempotency strategy" \
-  --body "Retry subscription updates up to 3x; dedupe by Stripe event id."
-
+rm -rf .devtime && dtc init && dtc scan
+dtc decision add --concept billing_webhooks --title "Use Stripe for billing" --body "We use Stripe as the payment provider and verify webhook signatures."
 dtc explain "Billing Webhooks"
 ```
 
-The uncertainty stays, with a corroboration note:
+Output (trimmed):
 
 ```
 Uncertainty:
-  - Decision 'Webhook retry and idempotency strategy' exists, but retry, deduplication
-    is not corroborated by scanned implementation evidence.
+  (none)
+
+Understanding Score: 79 / 100
+Understanding Debt: low
 ```
 
-Narration: *"DevTime will not raise the score for a decision the code does not back
-up. A decision is evidence, not automatic truth."*
+Narration: *"This decision matches the implementation, so the missing-decision
+uncertainty clears and the Understanding Score rises from 58 to 79."*
 
-Now contrast a decision that **matches** the implementation. On a fresh scan
-(`dtc reset && dtc init && dtc scan`), record a corroborated one:
+> Counter-example (optional, beat G): record a decision the code does NOT back up —
+> `dtc decision add --concept billing_webhooks --title "Retry strategy" --body "Retry up to 3x and dedupe by event id."`
+> DevTime keeps the uncertainty: *"Decision 'Retry strategy' exists, but retry,
+> deduplication is not corroborated by scanned implementation evidence."* A decision is
+> evidence, not automatic truth.
 
-```bash
-dtc decision add --concept billing_webhooks \
-  --title "Use Stripe for billing" \
-  --body "We use Stripe as the payment provider and verify webhook signatures."
+> PowerShell note: pass `--title`/`--body` inline on one line (as above). All demo
+> commands are single-line and work in bash, PowerShell, and cmd.
 
-dtc explain "Billing Webhooks"
-```
+## Close  (beat G)
 
-This decision matches the scanned Stripe signature-verification evidence, so the
-missing-decision uncertainty clears and the Understanding Score improves.
+Narration: *"DevTime is not magic and not an AI agent. It's evidence-backed local
+memory: it shows what the repository can prove, admits what it can't prove yet, warns
+about a narrow set of risky changes, and only rewards decisions the code corroborates."*
 
-Narration: *"A corroborated decision adds real understanding. DevTime distinguishes a
-decision that matches the code from one that merely claims behavior."*
-
-> PowerShell note: pass each option inline (as above) rather than a multi-line body.
-> `dtc decision add --concept billing_webhooks --title "..." --body "..."`
-
-## Close
-
-Narration: *"DevTime is not magic and not an AI agent. It is evidence-backed local
-memory: it shows what the repository can prove, admits what it cannot prove yet, and
-gives humans and agents safer context."*
-
-## Reset (optional)
+## Reset / revert — leave the repo clean
 
 ```bash
-dtc reset            # or: rm -rf .devtime
+rm -rf .devtime
+git checkout -- .          # restores stripe-webhook.ts and .devtimeignore
+git status                 # should report nothing in examples/demo-saas
 ```

--- a/PROOF.md
+++ b/PROOF.md
@@ -98,8 +98,9 @@ Admin Permissions in `38 signals` across `15 files` in ~0.1s.
 - **Authentication scores higher because an ADR exists** (`docs/decisions/0001-use-jwt.md`):
   its "why" is documented.
 - **Billing Webhooks scores lower because no decision exists**: strong behavior
-  evidence (route + Stripe signature verification + test) but Understanding Debt
-  `56/100` with explicit uncertainty "No decision was found explaining key choices".
+  evidence (route + Stripe signature verification + test) but Understanding Score
+  `58/100` (debt medium) with explicit uncertainty "No decision was found explaining
+  key choices".
 
 ## 4. Real repo validation proof
 
@@ -122,9 +123,11 @@ after **`confidence: high`** with real `app/api/.../route.ts` route evidence.
 longer detected** (its only billing association was an e2e spec path). Real billing
 webhooks (Snapilio PayPal, demo Stripe) are still correctly detected.
 
-**Demo — the decision loop:** `dtc explain "Billing Webhooks"` → Understanding Debt
-`56/100` with uncertainty. After `dtc decision add`, the uncertainty clears and debt
-improves to **`72/100`**.
+**Demo — the decision loop:** `dtc explain "Billing Webhooks"` → Understanding Score
+`58/100` (debt medium) with uncertainty. After a **corroborated** `dtc decision add`
+("Use Stripe for billing"), the uncertainty clears and the Understanding Score
+improves to **`79/100`** (debt low). An *uncorroborated* decision (e.g. claiming retry
+behavior the code lacks) leaves the uncertainty in place.
 
 **Demo — risk review:** with retry behavior changed and no duplicate-delivery test
 touched, `dtc risk --diff` flags **high severity**: "Retry behavior changed without

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -62,7 +62,7 @@ Scan complete. 15 files, 38 signals, 5 concepts in 0.1s.
 
 ```
 1. Billing Webhooks   confidence: high    debt: medium
-2. Authentication     confidence: high    debt: medium
+2. Authentication     confidence: high    debt: low
 3. Background Jobs    confidence: medium  debt: high
 4. Data Export        confidence: medium  debt: high
 5. Admin Permissions  confidence: medium  debt: high
@@ -70,7 +70,7 @@ Scan complete. 15 files, 38 signals, 5 concepts in 0.1s.
 
 `dtc explain "Billing Webhooks"` shows supported claims with evidence, an
 **Uncertainty** section ("No decision was found explaining key choices…"), an
-**Understanding Score** of `56 / 100` (higher = better), and an **Understanding Debt**
+**Understanding Score** of `58 / 100` (higher = better), and an **Understanding Debt**
 label (`medium`).
 
 V0 detects six supported concept families (closed ontology): Authentication, Billing

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The narrative:
 
 - **Before a decision:** Billing Webhooks has strong evidence (route, signature
   verification, test) *and* uncertainty — no decision explains its key choices.
-  Understanding Score is `56/100`.
+  Understanding Score is `58/100`.
 - **Risk review:** changing retry behavior without updating duplicate-delivery tests
   is flagged **high severity**.
 - **After a corroborated decision:** the reasoning is now in repository memory (and
@@ -160,7 +160,7 @@ Supported claims:
 Uncertainty:
   - No decision was found explaining key choices for Billing Webhooks.
 
-Understanding Score: 56 / 100
+Understanding Score: 58 / 100
 Understanding Debt: medium
 causes:
   - missing or uncorroborated decision evidence

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -70,8 +70,13 @@ public release gate.**
 
 ## 6. Demo
 
-- [x] Demo commands verified end to end
+- [x] Demo commands verified end to end (v0.0.7; see DEMO_SCRIPT.md / DEMO_OUTPUT.md)
+- [x] Expected output matches current behavior (Auth 79/low, Billing 58/medium → 79/low)
 - [x] Safe demo diff documented with revert step
+- [x] Risk-diff demo fires (high finding) and reverts cleanly
+- [x] Decision loop is truthful (corroborated improves; uncorroborated stays flagged)
+- [x] `git status` is clean after reset/revert (verified)
+- [x] Demo duration fits 2–3 minutes (~2m40s)
 - [ ] 2–3 minute demo video recorded *(pending — human)*
 
 ## 7. Packaging


### PR DESCRIPTION
## v0.0.8 demo candidate

Prepares and verifies the 2–3 minute public demo flow against the trusted v0.0.7 behavior. Documentation only — no product features, no concept-detection changes.

### What changed
- **DEMO_SCRIPT.md** rewritten to match current v0.0.7 output (Authentication 79/low; Billing Webhooks 58/medium → 79/low after a corroborated decision), with a bulletproof reset/revert that leaves `git status` clean.
- **DEMO_OUTPUT.md** added — exact command sequence, real expected output snippets, ~2m40s timing breakdown, what to say / not say on camera, reset/revert, and troubleshooting.
- **README.md / QUICKSTART.md / PROOF.md** — reconciled demo-number drift only (Billing 56→58, Authentication debt label → low, decision loop 56/72 → 58/79 with the corroboration distinction).
- **RELEASE_CHECKLIST.md** — demo section updated with the verified checks.

### Verified end to end (examples/demo-saas, v0.0.7)
- install/tests pass (88), `dtc init`/`scan`/`concepts`/`explain` all produce the documented output
- `dtc risk --diff` fires a high finding on the retry diff and reverts cleanly
- corroborated decision improves Understanding Score 58 → 79; uncorroborated decision stays flagged
- `git status` clean after reset/revert

### Confirmations
- No public release. No new product features. No concept-detection changes.
- Package version remains **0.0.7** (not bumped; `0.1.0` not created).
- Repo remains **private**.

Do not merge or tag automatically — waiting for approval.
