### PR TITLE
v0.1.1 public onboarding

### DIFF
--- a/CLEAN_INSTALL_CHECK.md
+++ b/CLEAN_INSTALL_CHECK.md
@@ -16,7 +16,7 @@ python -m venv .venv
 source .venv/Scripts/activate        # Windows Git Bash; use .venv/bin/activate on macOS/Linux
 
 pip install -e ".[dev]"
-pytest                               # expect: all tests pass (77+)
+pytest                               # expect: all tests pass (88 tests)
 
 cd examples/demo-saas
 dtc init
@@ -37,7 +37,7 @@ To exercise the advisory risk review, follow the prepared diff in
 | OS | Windows 11 (Git Bash) |
 | Python | 3.11.9 |
 | Install command | `pip install -e ".[dev]"` |
-| Test result | **all passed (77+)** |
+| Test result | **88 passed** |
 | `dtc` on PATH | yes (inside the activated venv) |
 | Demo result | scan / concepts / explain produced expected output |
 | Issue found | `dtc risk --diff` reported no findings when the scan root is a subdirectory of the git repo (diff paths were repo-relative, evidence paths scan-root-relative) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to DevTime
+
+Thanks for helping. The single most valuable contribution is a **fixture** - a small
+repository pattern that captures something DevTime got wrong (or should keep getting
+right) so it can never silently regress.
+
+## The best contribution is a fixture
+
+A fixture is a tiny repo plus the expected output: which concepts should (or should
+not) be detected, which claims are allowed, which are forbidden, and what uncertainty
+is required. When DevTime is wrong on real code, turning that into a fixture is what
+makes the fix permanent. See `fixtures/` for the format and `tests/` for how they run.
+
+## "DevTime got this wrong" reports are valuable
+
+If DevTime over-claims, under-claims, mislabels a concept, or misses one, please open
+a **"DevTime got this wrong"** issue (there is a template). Include:
+
+- a minimal reproduction (a tiny sanitized repo or snippet) or the public repo + path
+- the exact command you ran (e.g. `dtc explain "Authentication"`)
+- the expected output
+- the actual output
+- why the claim is too strong, too weak, or missing
+
+Please do **not** include secrets or private source. File paths and small sanitized
+snippets are enough. If you can, attach a small fixture repo/pattern that reproduces
+it.
+
+## Trust rules contributions must preserve
+
+DevTime is a trust system. Any change must keep these true:
+
+- no claim without evidence
+- weak or missing evidence produces uncertainty, not confidence
+- no network access and no code execution during a scan
+- ignored files and secrets never become evidence
+- risk review is advisory (it does not block PRs)
+
+## Local dev workflow
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+pytest
+```
+
+On Windows PowerShell, activate with:
+
+```powershell
+.venv\Scripts\Activate.ps1
+```
+
+Run the full suite before opening a PR; new behavior should come with a fixture or
+test that pins it.

--- a/PUBLIC_FEEDBACK_PLAN.md
+++ b/PUBLIC_FEEDBACK_PLAN.md
@@ -1,0 +1,76 @@
+# Public Feedback Plan
+
+Five GitHub issues to open after the v0.1.1 onboarding PR merges. These are drafts -
+do not open them automatically. They seed a public backlog and invite contribution.
+
+---
+
+## 1. Improve first-run install flow
+
+**Why it matters:** Right now install is `git clone` + `pip install -e ".[dev]"`,
+which is fine for contributors but heavy for someone who just wants to try the tool.
+A one-line install would meaningfully raise the number of people who actually run it.
+
+**Suggested scope:**
+- Investigate publishing to PyPI so `pip install devtime` / `pipx install devtime` works.
+- Keep the editable dev install documented for contributors.
+- Update README install instructions and badges once available.
+
+**What not to do yet:** Do not change CLI behavior, commands, or scan logic. Packaging
+only.
+
+---
+
+## 2. Add clearer line-number evidence
+
+**Why it matters:** Evidence currently cites files; pointing to the specific
+route/handler/line would make claims easier to audit and trust.
+
+**Suggested scope:**
+- Capture and surface start/end lines where the extractors already have them.
+- Show line ranges in `dtc explain` and `dtc evidence` output.
+
+**What not to do yet:** Do not expand the concept ontology or change detection. This
+is presentation/precision of existing evidence, not new detection.
+
+---
+
+## 3. Add more real-world fixtures
+
+**Why it matters:** DevTime gets more trustworthy as more real wrong/right outputs
+become fixtures. Community repos are the best source.
+
+**Suggested scope:**
+- Add fixtures from frameworks and patterns not yet covered.
+- Prioritize "DevTime got this wrong" reports from real users.
+
+**What not to do yet:** Do not loosen the trust gates to make a repo pass. A fixture
+should pin correct behavior, not paper over a bug.
+
+---
+
+## 4. Design GitHub Action advisory PR review
+
+**Why it matters:** Running `dtc risk --diff` in pull requests is the natural team
+on-ramp, and it stays advisory (the project's trust stance).
+
+**Suggested scope:**
+- Prototype an Action that runs `dtc init`, `dtc scan`, `dtc risk --diff` on a PR.
+- Post advisory comments only.
+
+**What not to do yet:** No blocking by default. No blocking on weak claims. No cloud
+service. Keep it advisory and opt-in.
+
+---
+
+## 5. Improve README "why this matters" section
+
+**Why it matters:** The clearer the problem framing (Git remembers code, not
+understanding), the more a stranger self-identifies and tries the tool.
+
+**Suggested scope:**
+- Tighten the problem statement and the "Who it is for" examples.
+- Consider an inline animated terminal demo at the top.
+
+**What not to do yet:** Do not overclaim, do not imply AI/automation, and keep the
+no-cloud/no-telemetry/no-code-execution/no-AI language.

--- a/README.md
+++ b/README.md
@@ -2,30 +2,101 @@
 
 **Local-first Engineering Intelligence for software repositories.**
 
-DevTime helps a repository explain itself from evidence. It scans code, tests,
-configs, routes, and decisions to identify the concepts inside a codebase, show the
-evidence behind them, surface uncertainty, and warn about risky changes.
+DevTime helps a codebase explain itself from evidence.
 
-It does not execute your code. It does not send your code anywhere. It does not
-require AI. It does not pretend to know things without evidence.
+It scans code, tests, configs, routes, and decisions to identify supported software
+concepts, link claims to files, surface uncertainty, and warn about a narrow set of
+risky changes.
 
 > No cloud. No telemetry. No code execution. No AI required.
 
+[![DevTime demo - Repository memory from evidence](assets/devtime-demo-thumbnail-v0.1.0.png)](https://youtu.be/1Hiu3Y9J_SI)
+
+Watch the 2-minute demo: DevTime scans a repo locally, explains concepts from
+evidence, surfaces uncertainty, catches a risky diff, and shows how a corroborated
+decision improves understanding.
+
 ---
+
+## Try DevTime in 60 seconds
+
+```bash
+git clone https://github.com/Shakargy/devtime.git
+cd devtime
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+cd examples/demo-saas
+dtc init
+dtc scan
+dtc concepts
+dtc explain "Billing Webhooks"
+```
+
+On Windows PowerShell:
+
+```powershell
+git clone https://github.com/Shakargy/devtime.git
+cd devtime
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
+cd examples/demo-saas
+dtc init
+dtc scan
+dtc concepts
+dtc explain "Billing Webhooks"
+```
+
+You should see Billing Webhooks explained from evidence, including supported claims,
+file references, uncertainty, Understanding Score, and Understanding Debt.
+
+To test risk review, make a local change first, then run:
+
+```bash
+dtc risk --diff
+```
+
+A full, copy-pasteable walkthrough (including the risk-diff and corroborated-decision
+steps) is in **[DEMO_SCRIPT.md](DEMO_SCRIPT.md)**.
 
 ## Why this exists
 
-Git remembers *code*. It does not remember *understanding* - why a behavior exists,
-what evidence supports it, or what nobody has decided yet. As AI tools generate code
-faster than teams can review it, that missing understanding becomes the bottleneck.
+Git remembers code. It does not remember understanding. It does not tell you why a
+behavior exists, what evidence supports it, or what nobody has decided yet. As AI
+tools generate code faster than teams can review it, that missing understanding
+becomes the bottleneck.
 
-DevTime builds **evidence-backed repository memory**: a local layer that says what a
+DevTime builds evidence-backed repository memory: a local layer that says what a
 repository can prove, and - just as importantly - what it cannot prove yet.
 
-## Supported concepts (closed ontology)
+## Who it is for
 
-V0 detects **six** supported concept families - it does not discover arbitrary
-domain concepts yet:
+DevTime is for developers reviewing unfamiliar code, teams using AI coding tools, and
+maintainers who want repository understanding to be backed by evidence instead of
+generated summaries.
+
+It is useful when you want to ask:
+
+- where is authentication actually implemented?
+- what files prove that billing webhooks exist?
+- what is still uncertain?
+- did this diff touch a risky concept?
+- is there a decision explaining this behavior?
+
+## What DevTime does
+
+- Detects concepts from routes, tests, configs, dependencies, and docs.
+- Explains from evidence by linking claims to files and signals.
+- Surfaces uncertainty when evidence is missing or weak.
+- Scores understanding with an Understanding Score and Understanding Debt label.
+- Reviews narrow risky diffs with advisory findings from local memory.
+- Records decisions locally so rationale can reduce uncertainty when corroborated by code.
+
+## Supported concepts
+
+V0 detects six supported concept families. It does not discover arbitrary domain
+concepts yet:
 
 - Authentication
 - Billing Webhooks
@@ -35,25 +106,6 @@ domain concepts yet:
 - File Uploads
 
 Anything outside these six is out of scope for V0. See [LIMITATIONS.md](LIMITATIONS.md).
-
-## What DevTime does
-
-- **Detects concepts** - the six supported families above - from routes, tests,
-  configs, dependencies, and docs, with word-sense gates so a coincidental keyword
-  (a job *title*, an avatar *URL*, a `session_id` trace) does not invent a concept.
-- **Explains from evidence** - every claim links to the files/signals behind it.
-- **Surfaces uncertainty** - when evidence is missing (e.g. no decision record), it
-  says so instead of guessing.
-- **Scores understanding** - an **Understanding Score** (higher = better) with an
-  **Understanding Debt** label (low/medium/high) and the causes shown.
-- **Warns about a narrow set of risky changes** - `dtc risk --diff` reviews a git
-  diff against local memory and flags *advisory* findings for the change classes it
-  supports (e.g. JWT algorithm weakening, billing-webhook retry without dedupe tests).
-  It reports explicit states: `review_failed`, `no_findings`,
-  `unsupported_change_class` (a known-concept file changed but no rule covers it), and
-  `finding`. "No findings" never means "could not inspect".
-- **Records decisions** - `dtc decision add` stores rationale locally, which reduces
-  uncertainty and improves understanding.
 
 ## What DevTime does not do
 
@@ -65,8 +117,6 @@ Anything outside these six is out of scope for V0. See [LIMITATIONS.md](LIMITATI
 - It is **not** a documentation generator, a static analyzer, an observability tool,
   a productivity tracker, or an AI coding agent.
 
-See **[LIMITATIONS.md](LIMITATIONS.md)** for the full, honest list.
-
 ## Trust model
 
 - DevTime stores local repository memory in `.devtime/` (a local SQLite database).
@@ -76,63 +126,8 @@ See **[LIMITATIONS.md](LIMITATIONS.md)** for the full, honest list.
   never become evidence or claims.
 - Every claim must link to evidence - *no claim without evidence*.
 - Weak evidence produces **uncertainty**, not confidence.
-- *Usage is not decision*: that a dependency is used does not mean someone decided
-  why.
+- *Usage is not decision*: that a dependency is used does not mean someone decided why.
 - Risk review is **advisory** by default - it does not block PRs.
-
-## Quick demo
-
-DevTime scans the **current directory**, so the demo runs from inside the demo app.
-
-```bash
-cd examples/demo-saas
-dtc init
-dtc scan
-dtc concepts
-dtc explain "Billing Webhooks"
-# ...make a change, then:
-dtc risk --diff
-# A decision only clears uncertainty when the code backs it up (corroborated):
-dtc decision add --concept billing_webhooks \
-  --title "Use Stripe for billing" \
-  --body "We use Stripe as the payment provider and verify webhook signatures."
-dtc explain "Billing Webhooks"
-```
-
-The narrative:
-
-- **Before a decision:** Billing Webhooks has strong evidence (route, signature
-  verification, test) *and* uncertainty - no decision explains its key choices.
-  Understanding Score is `58/100`.
-- **Risk review:** changing retry behavior without updating duplicate-delivery tests
-  is flagged **high severity**.
-- **After a corroborated decision:** the reasoning is now in repository memory (and
-  matches the code), the uncertainty clears, and the Understanding Score improves.
-  A decision that the code does *not* back up stays flagged as uncorroborated.
-
-A full, copy-pasteable walkthrough is in **[DEMO_SCRIPT.md](DEMO_SCRIPT.md)**.
-
-## Demo
-
-[![DevTime demo - Repository memory from evidence](assets/devtime-demo-thumbnail-v0.1.0.png)](https://youtu.be/1Hiu3Y9J_SI)
-
-Watch the 2-minute demo: DevTime scans a repo locally, explains concepts from evidence, surfaces uncertainty, catches a risky diff, and shows how a corroborated decision improves understanding.
-
-## Installation
-
-Requires **Python ≥ 3.11** and git.
-
-```bash
-git clone https://github.com/Shakargy/devtime.git
-cd devtime
-python -m venv .venv
-source .venv/bin/activate          # Windows: .venv\Scripts\activate
-pip install -e ".[dev]"
-pytest                              # the full test suite should pass (77+ tests)
-```
-
-This installs the `dtc` command. See **[QUICKSTART.md](QUICKSTART.md)** for a
-step-by-step first run and troubleshooting.
 
 ## Commands
 
@@ -148,6 +143,9 @@ step-by-step first run and troubleshooting.
 
 (Also available: `dtc evidence`, `dtc debt`, `dtc status`, `dtc doctor --privacy`,
 `dtc export`, `dtc reset`.)
+
+Requires **Python >= 3.11** and git. See **[QUICKSTART.md](QUICKSTART.md)** for a
+step-by-step first run and troubleshooting.
 
 ## Example output
 
@@ -184,7 +182,7 @@ blindness, a false Billing Webhooks detection on a generic webhook system, a DB
 migration mis-counted as Background Jobs evidence, and more). Each failure became a
 fixture so it cannot silently regress.
 
-- Tests grew from 13 to 77+ as each real failure became a fixture.
+- Tests grew from 13 to 88 as real failures became fixtures.
 - Scan time on a 355-file real repo dropped from ~27.3s to ~0.48s after ignored-
   directory pruning.
 
@@ -213,14 +211,14 @@ intentionally not built yet - in **[LIMITATIONS.md](LIMITATIONS.md)**.
 
 This is an early, local-first V0 focused on being trustworthy before being large.
 Not yet built (intentionally): git-history signals, wired MCP transport, an AI
-provider, a UI, and any cloud/team/enterprise features. See LIMITATIONS.md.
+provider, a UI, and any cloud/team/enterprise features. See **[ROADMAP.md](ROADMAP.md)**.
 
 ## Contributing
 
 The most valuable contribution is a **fixture**: a small repository pattern plus the
 expected concepts, allowed claims, forbidden claims, and required uncertainty. If
 DevTime gets something wrong on your code, that wrong output can become a fixture so
-it never regresses. See `fixtures/` for the format and `tests/` for how they run.
+it never regresses. See **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,47 @@
+# Roadmap
+
+DevTime is an early, local-first tool focused on being trustworthy before being
+large. This roadmap is a direction, not a dated commitment - order and scope may
+change based on real feedback.
+
+## Current release - v0.1.0
+
+- Local scan (no cloud, no telemetry, no code execution, no AI).
+- Six supported concept families (closed ontology).
+- Evidence-linked, strength-aware claims with explicit uncertainty.
+- Understanding Score and Understanding Debt.
+- Advisory, narrow `dtc risk --diff`.
+- Governed, capped, evidence-based Context Packs.
+- Corroborated decision records.
+
+## v0.1.1 - Public onboarding and trust patch
+
+- README and onboarding improvements (faster first run, "Try in 60 seconds").
+- `CONTRIBUTING.md` and a clearer issue flow.
+- Public feedback turned into fixtures.
+- Docs fixes from first users.
+
+## v0.2 - Evidence precision and first-run UX
+
+- Exact line-number evidence where available.
+- Better `dtc status` and `dtc doctor --privacy` output.
+- Stronger unsupported-framework warnings.
+- More real-world fixtures.
+- Clearer large-repo scan output.
+
+## v0.3 - GitHub Action advisory PR review
+
+- A GitHub Action prototype that runs `dtc risk --diff` in pull requests.
+- Advisory PR comments only.
+- No blocking by default; no blocking on weak claims.
+
+## Later
+
+- Read-only MCP transport.
+- A local UI.
+- Shared team decisions.
+- Understanding Debt history over time.
+- An optional hosted/team product, only if it earns its place.
+
+Have an opinion on priorities? Open an issue - real usage shapes this more than a
+plan does.


### PR DESCRIPTION
## v0.1.1 public onboarding

Improves README conversion and public onboarding so a stranger can understand DevTime and try it in 60 seconds. Docs only - no product behavior changes, no version bump, no tag.

- Reorders the README top for faster first-run conversion (positioning, trust line, demo thumbnail, then "Try DevTime in 60 seconds").
- Adds "Try DevTime in 60 seconds" with bash and PowerShell one-shot copy-paste blocks; folds the old Installation/Quick demo into it.
- Moves the demo thumbnail near the top.
- Adds "Who it is for".
- Fixes stale test-count references (77+ -> 88).
- Adds CONTRIBUTING.md (the best contribution is a fixture; "DevTime got this wrong" issue guidance; trust rules; dev workflow).
- Adds ROADMAP.md (v0.1.0 / v0.1.1 / v0.2 / v0.3 / Later, no dates).
- Adds PUBLIC_FEEDBACK_PLAN.md (5 suggested issues, not opened).
- Preserves trust-first positioning and the no-cloud/no-telemetry/no-code-execution/no-AI language.

No product features, no concept-detection/risk/scan changes, no version bump, no tag.
