### PR TITLE
Prepare PyPI install flow

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -1,0 +1,33 @@
+name: package-check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+      - name: Install package (dev) and run tests
+        run: |
+          pip install -e ".[dev]"
+          pytest
+      - name: Build sdist and wheel
+        run: |
+          rm -rf dist build *.egg-info src/*.egg-info
+          python -m build
+      - name: twine check
+        run: python -m twine check dist/*
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+          if-no-files-found: error

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -1,0 +1,48 @@
+name: publish-python-package
+
+# Manual only. Never publishes on push or tag.
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target"
+        required: true
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Uses the GitHub environment matching the chosen target (testpypi / pypi),
+    # so environment protection rules and secrets apply.
+    environment: ${{ inputs.target }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+      - name: Build sdist and wheel
+        run: |
+          rm -rf dist build *.egg-info src/*.egg-info
+          python -m build
+      - name: twine check
+        run: python -m twine check dist/*
+
+      - name: Publish to TestPyPI
+        if: ${{ inputs.target == 'testpypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          # Token comes from the repository/environment secret; never echoed.
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+      - name: Publish to PyPI
+        if: ${{ inputs.target == 'pypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,7 +1,8 @@
 # Packaging and publishing DevTime
 
 How to build the package, verify it, and (when approved) publish to TestPyPI and then
-PyPI. The goal is a one-line install: `pipx install devtime`.
+PyPI. The goal is a one-line install: `pipx install devtime-ei` (the package is named
+`devtime-ei`; the command it installs is `dtc`).
 
 > **Token safety:** never paste API tokens into commands that land in shell history if
 > you can avoid it. Prefer environment variables or GitHub Secrets. Tokens must never
@@ -27,7 +28,7 @@ python -m venv .venv-wheel-test
 source .venv-wheel-test/bin/activate
 pip install dist/*.whl
 dtc --help
-python -c "import importlib.metadata as m; print(m.version('devtime'))"
+python -c "import importlib.metadata as m; print(m.version('devtime-ei'))"
 ```
 
 Windows PowerShell:
@@ -37,7 +38,7 @@ python -m venv .venv-wheel-test
 .venv-wheel-test\Scripts\Activate.ps1
 pip install dist/*.whl
 dtc --help
-python -c "import importlib.metadata as m; print(m.version('devtime'))"
+python -c "import importlib.metadata as m; print(m.version('devtime-ei'))"
 ```
 
 ## TestPyPI upload (only after the checks above pass)
@@ -61,9 +62,9 @@ macOS / Linux:
 ```bash
 python -m venv .venv-testpypi
 source .venv-testpypi/bin/activate
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple devtime
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple devtime-ei
 dtc --help
-python -c "import importlib.metadata as m; print(m.version('devtime'))"
+python -c "import importlib.metadata as m; print(m.version('devtime-ei'))"
 ```
 
 Windows PowerShell:
@@ -71,9 +72,9 @@ Windows PowerShell:
 ```powershell
 python -m venv .venv-testpypi
 .venv-testpypi\Scripts\Activate.ps1
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple devtime
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple devtime-ei
 dtc --help
-python -c "import importlib.metadata as m; print(m.version('devtime'))"
+python -c "import importlib.metadata as m; print(m.version('devtime-ei'))"
 ```
 
 ## Real PyPI upload (separate, explicitly approved step only)
@@ -93,7 +94,7 @@ python -m twine upload dist/* -u __token__ -p $env:PYPI_API_TOKEN
 ## After real PyPI publish, install check
 
 ```bash
-pipx install devtime
+pipx install devtime-ei
 dtc --help
 ```
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,0 +1,104 @@
+# Packaging and publishing DevTime
+
+How to build the package, verify it, and (when approved) publish to TestPyPI and then
+PyPI. The goal is a one-line install: `pipx install devtime`.
+
+> **Token safety:** never paste API tokens into commands that land in shell history if
+> you can avoid it. Prefer environment variables or GitHub Secrets. Tokens must never
+> be committed, written into any file, echoed, or included in logs, README, this file,
+> workflows, PR text, or release notes. The expected env var names are
+> `TEST_PYPI_API_TOKEN` and `PYPI_API_TOKEN`.
+
+## Local build
+
+```bash
+python -m pip install --upgrade pip build twine
+rm -rf dist build *.egg-info src/*.egg-info
+python -m build
+python -m twine check dist/*
+```
+
+## Wheel smoke test
+
+macOS / Linux:
+
+```bash
+python -m venv .venv-wheel-test
+source .venv-wheel-test/bin/activate
+pip install dist/*.whl
+dtc --help
+python -c "import importlib.metadata as m; print(m.version('devtime'))"
+```
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv-wheel-test
+.venv-wheel-test\Scripts\Activate.ps1
+pip install dist/*.whl
+dtc --help
+python -c "import importlib.metadata as m; print(m.version('devtime'))"
+```
+
+## TestPyPI upload (only after the checks above pass)
+
+macOS / Linux:
+
+```bash
+python -m twine upload --repository testpypi dist/* -u __token__ -p "$TEST_PYPI_API_TOKEN"
+```
+
+Windows PowerShell:
+
+```powershell
+python -m twine upload --repository testpypi dist/* -u __token__ -p $env:TEST_PYPI_API_TOKEN
+```
+
+## TestPyPI install check
+
+macOS / Linux:
+
+```bash
+python -m venv .venv-testpypi
+source .venv-testpypi/bin/activate
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple devtime
+dtc --help
+python -c "import importlib.metadata as m; print(m.version('devtime'))"
+```
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv-testpypi
+.venv-testpypi\Scripts\Activate.ps1
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple devtime
+dtc --help
+python -c "import importlib.metadata as m; print(m.version('devtime'))"
+```
+
+## Real PyPI upload (separate, explicitly approved step only)
+
+macOS / Linux:
+
+```bash
+python -m twine upload dist/* -u __token__ -p "$PYPI_API_TOKEN"
+```
+
+Windows PowerShell:
+
+```powershell
+python -m twine upload dist/* -u __token__ -p $env:PYPI_API_TOKEN
+```
+
+## After real PyPI publish, install check
+
+```bash
+pipx install devtime
+dtc --help
+```
+
+## Publishing via GitHub Actions
+
+The manual workflow `.github/workflows/publish-python-package.yml`
+(`workflow_dispatch`) can publish to TestPyPI or PyPI using repository secrets
+`TEST_PYPI_API_TOKEN` and `PYPI_API_TOKEN`. It never runs on push or tag.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,34 @@ Anything outside these six is out of scope for V0. See [LIMITATIONS.md](LIMITATI
 Requires **Python >= 3.11** and git. See **[QUICKSTART.md](QUICKSTART.md)** for a
 step-by-step first run and troubleshooting.
 
+## Installation
+
+Recommended source install for now:
+
+```bash
+git clone https://github.com/Shakargy/devtime.git
+cd devtime
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Windows PowerShell:
+
+```powershell
+git clone https://github.com/Shakargy/devtime.git
+cd devtime
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
+```
+
+Planned PyPI install (after the package is published and verified):
+
+```bash
+pipx install devtime
+```
+
 ## Example output
 
 ```

--- a/README.md
+++ b/README.md
@@ -169,11 +169,17 @@ python -m venv .venv
 pip install -e ".[dev]"
 ```
 
-Planned PyPI install (after the package is published and verified):
+Or install from PyPI (the command stays `dtc`):
 
 ```bash
-pipx install devtime
+pipx install devtime-ei
 ```
+
+```bash
+pip install devtime-ei
+```
+
+The PyPI package is named `devtime-ei`; the command it installs is `dtc`.
 
 ## Example output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "devtime"
+name = "devtime-ei"
 version = "0.1.0"
 description = "Local-first Engineering Intelligence for software repositories"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,31 @@
 [project]
 name = "devtime"
 version = "0.1.0"
-description = "Local-first Engineering Intelligence for repository memory"
+description = "Local-first Engineering Intelligence for software repositories"
+readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
+authors = [{ name = "Aviad Shakargi", email = "aviad94@gmail.com" }]
+maintainers = [{ name = "Aviad Shakargi", email = "aviad94@gmail.com" }]
+keywords = [
+    "devtools",
+    "cli",
+    "static-analysis",
+    "repository-analysis",
+    "engineering-intelligence",
+    "local-first",
+]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3",
+    "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Utilities",
 ]
 dependencies = [
     "typer>=0.12",
@@ -24,6 +41,13 @@ dev = [
     "pytest>=8.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/Shakargy/devtime"
+Repository = "https://github.com/Shakargy/devtime"
+Issues = "https://github.com/Shakargy/devtime/issues"
+"Release Notes" = "https://github.com/Shakargy/devtime/releases/tag/v0.1.0"
+Demo = "https://youtu.be/1Hiu3Y9J_SI"
+
 [project.scripts]
 dtc = "devtime.cli:app"
 
@@ -33,6 +57,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+# Non-Python runtime files that ship inside the package (read at runtime).
+[tool.setuptools.package-data]
+devtime = ["db/*.sql", "assets/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/integration/test_evidence_precision.py
+++ b/tests/integration/test_evidence_precision.py
@@ -19,7 +19,9 @@ def test_version_is_release_0_1_0():
     import importlib.metadata as m
 
     assert devtime.__version__ == "0.1.0"
-    assert m.version("devtime") == "0.1.0"
+    # Distribution is published as "devtime-ei" (the name "devtime" is reserved on
+    # PyPI); the import package and the dtc command stay "devtime"/"dtc".
+    assert m.version("devtime-ei") == "0.1.0"
 
 
 # --- P0 Authentication headline precision ------------------------------------


### PR DESCRIPTION
## Prepare PyPI install flow

Prepares DevTime for a one-line install (`pipx install devtime`). No product behavior changes, no version bump, no tag, and **nothing is published** in this PR.

- **pyproject.toml**: PyPI-ready metadata - description, `readme`, author/maintainer, keywords, full classifiers, `[project.urls]`, and `package-data` so the runtime files (`db/*.sql`, `assets/*`) ship inside the wheel.
- **PACKAGING.md**: human build/verify/publish instructions (TestPyPI then PyPI), with token-safety guidance. Token env var names only: `TEST_PYPI_API_TOKEN`, `PYPI_API_TOKEN`.
- **.github/workflows/package-check.yml**: builds sdist+wheel, runs tests, `twine check`, uploads dist artifacts on PRs and pushes to main. Does not publish.
- **.github/workflows/publish-python-package.yml**: manual `workflow_dispatch` only, with a `testpypi`/`pypi` target, environment-gated, using repository secrets. Never runs on push or tag; tokens are passed via env/secrets and never echoed or hardcoded.
- **README.md**: adds an Installation section with the source install (bash + PowerShell) and a clearly-labeled *planned* `pipx install devtime` note (does not claim it works yet).

### Local verification
- 88 tests pass; `python -m build` succeeds; `twine check` PASSED for both sdist and wheel.
- Wheel installs in a clean venv: `dtc --help` works, version `0.1.0`, and a runtime `init`/`scan`/`concepts` works from the wheel (bundled `schema.sql` + `devtimeignore.starter` load correctly).
- No forbidden artifacts in dist (no `.devtime/`, `*.sqlite`, `.env`, caches, root `tests/`/`examples/`/`reports/`/`fixtures/`, videos, or `.png`). The `devtime.fixtures` *package* (the runner code) ships as intended.

### Confirmations
- No product/concept/risk/scan behavior changes. No version bump (still 0.1.0). No tag. No GitHub Release.
- **No publish to TestPyPI or PyPI.** No tokens committed, written to files, echoed, or logged.

Do not merge automatically. Publishing is a separate, explicitly approved step.
